### PR TITLE
[479] feat: Changed demo button

### DIFF
--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -94,6 +94,20 @@ button,
 	display: block;
 }
 
+.Button--demo {
+	display: block;
+	padding: 0 $button-padding-normal + 10px !important;
+}
+
+.Button--trial--wrapper {
+
+	@media (max-width: $breakpoint-desktop) {
+		width: 100%;
+		display: flex;
+		justify-content: center;
+	}
+}
+
 .Button--normal {
 	color: #fff;
 	background-color: #fa9531;

--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -104,22 +104,6 @@ button,
 	}
 }
 
-.Header__buttons {
-	display: flex;
-
-	@media (max-width: $breakpoint-desktop) {
-		width: 100%;
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		justify-content: center;
-	}
-
-	@media (max-width: $breakpoint-mobile) {
-		flex-direction: column;
-	}
-}
-
 .Button--normal {
 	color: #fff;
 	background-color: #fa9531;

--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -96,7 +96,7 @@ button,
 
 .Button--demo {
 	display: block;
-	padding: 0 $button-padding-normal + 10px !important;
+	padding: 0 3.215em !important;
 }
 
 .Button--trial--wrapper {

--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -104,9 +104,8 @@ button,
 	}
 }
 
-.Buttons--wrapper {
+.Header__buttons {
 	display: flex;
-	flex-direction: row;
 
 	@media (max-width: $breakpoint-desktop) {
 		width: 100%;

--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -97,14 +97,27 @@ button,
 .Button--demo {
 	display: block;
 	padding: 0 3.215em !important;
+	margin-right: 1em;
+
+	@media (max-width: $breakpoint-mobile) {
+		margin-right: 0;
+	}
 }
 
-.Button--trial--wrapper {
+.Buttons--wrapper {
+	display: flex;
+	flex-direction: row;
 
 	@media (max-width: $breakpoint-desktop) {
 		width: 100%;
 		display: flex;
+		flex-direction: row;
+		align-items: center;
 		justify-content: center;
+	}
+
+	@media (max-width: $breakpoint-mobile) {
+		flex-direction: column;
 	}
 }
 

--- a/assets/styles/layouts/_Header.scss
+++ b/assets/styles/layouts/_Header.scss
@@ -60,6 +60,22 @@
 .Header__navigation {
 	display: flex;
 
+	&__buttons {
+		display: flex;
+
+		@media (max-width: $breakpoint-desktop) {
+			width: 100%;
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: center;
+		}
+
+		@media (max-width: $breakpoint-mobile) {
+			flex-direction: column;
+		}
+	}
+
 	.Button {
 		top: 9px;
 		margin-left: 15px;

--- a/templates/header.php
+++ b/templates/header.php
@@ -33,11 +33,11 @@
 				endif;
 				?>
 
-				<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
-					<span><?php _e( 'Demo', 'ms' ); ?></span>
-				</a>
+				<div class="Buttons--wrapper">
+					<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
+						<span><?php _e( 'Demo', 'ms' ); ?></span>
+					</a>
 
-				<div class="Button--trial--wrapper">
 					<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Free Trial'])">
 						<span><?php _e( 'Free Trial', 'ms' ); ?></span>
 					</a>

--- a/templates/header.php
+++ b/templates/header.php
@@ -33,9 +33,15 @@
 				endif;
 				?>
 
-				<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Free Trial'])">
-					<span><?php _e( 'Free Trial', 'ms' ); ?></span>
+				<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
+					<span><?php _e( 'Demo', 'ms' ); ?></span>
 				</a>
+
+				<div class="Button--trial--wrapper">
+					<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Free Trial'])">
+						<span><?php _e( 'Free Trial', 'ms' ); ?></span>
+					</a>
+				</div>
 
 				<a href="<?php _e( '/login/', 'ms' ); ?>" class="Button Button--login" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Login'])">
 					<span><?php _e( 'Login', 'ms' ); ?></span>

--- a/templates/header.php
+++ b/templates/header.php
@@ -33,7 +33,7 @@
 				endif;
 				?>
 
-				<div class="Buttons--wrapper">
+				<div class="Header__buttons">
 					<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
 						<span><?php _e( 'Demo', 'ms' ); ?></span>
 					</a>

--- a/templates/header.php
+++ b/templates/header.php
@@ -33,7 +33,7 @@
 				endif;
 				?>
 
-				<div class="Header__buttons">
+				<div class="Header__navigation__buttons">
 					<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
 						<span><?php _e( 'Demo', 'ms' ); ?></span>
 					</a>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added demo button next to free trial, added wrapping div around free trial for better responsivity

**Testing instructions**
We need to remove former demo button from navigation menu (both normal and mobile) in WP.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#479
