### PR TITLE
[479] fix: changed padding of Demo button

### DIFF
--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -391,3 +391,35 @@ button,
 	}
 
 }
+
+html[lang="es-ES"] .Button--demo {
+	padding: 0 1.8em !important;
+}
+
+html[lang="hr-HR"] .Button--demo {
+	padding: 0 1.8em !important;
+}
+
+html[lang="lv-LV"] .Button--demo {
+	padding: 0 1.3em !important;
+}
+
+html[lang="ro-RO"] .Button--demo {
+	padding: 0 2.4em !important;
+}
+
+html[lang="sk-SK"] .Button--demo {
+	padding: 0 2.8em !important;
+}
+
+html[lang="tl-PH"] .Button--demo {
+	padding: 0 2.9em !important;
+}
+
+html[lang="vi-VN"] .Button--demo {
+	padding: 0 1.7em !important;
+}
+
+html[lang="de-DE"] .Button--demo {
+	padding: 0 2.4em !important;
+}

--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -396,7 +396,7 @@ html[lang="es-ES"] .Button--demo {
 	padding: 0 1.8em !important;
 }
 
-html[lang="hr-HR"] .Button--demo {
+html[lang="hr"] .Button--demo {
 	padding: 0 1.8em !important;
 }
 
@@ -412,7 +412,7 @@ html[lang="sk-SK"] .Button--demo {
 	padding: 0 2.8em !important;
 }
 
-html[lang="tl-PH"] .Button--demo {
+html[lang="tl"] .Button--demo {
 	padding: 0 2.9em !important;
 }
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
In relation to redesign of Demo button in main navigation, in few languages it was too wide, so I have applied smaller padding on the button.

**Testing instructions**

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Note**
after closing this PR we need to delete hotfix for these languages in WP