### PR TITLE
[514] feat: reverted demo button to its original state

### DIFF
--- a/assets/styles/elements/_Button.scss
+++ b/assets/styles/elements/_Button.scss
@@ -94,20 +94,6 @@ button,
 	display: block;
 }
 
-.Button--demo {
-	display: block;
-	padding: 0 3.215em !important;
-	margin-right: 0;
-
-	@media (max-width: $breakpoint-desktop) {
-		margin-right: 1em;
-	}
-
-	@media (max-width: $breakpoint-mobile) {
-		margin-right: 0;
-	}
-}
-
 .Button--normal {
 	color: #fff;
 	background-color: #fa9531;

--- a/assets/styles/layouts/_Header.scss
+++ b/assets/styles/layouts/_Header.scss
@@ -78,7 +78,7 @@
 
 	.Button {
 		top: 9px;
-		margin-left: 10px;
+		margin-left: 15px;
 		height: 44px;
 
 		span {

--- a/templates/header.php
+++ b/templates/header.php
@@ -34,10 +34,6 @@
 				?>
 
 				<div class="Header__navigation__buttons">
-					<a href="<?php _e( '/demo/', 'ms' ); ?>" class="Button Button--outline Button--demo" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Demo'])">
-						<span><?php _e( 'Demo', 'ms' ); ?></span>
-					</a>
-
 					<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Free Trial'])">
 						<span><?php _e( 'Free Trial', 'ms' ); ?></span>
 					</a>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed demo button to its original state: 
- removed as standalone button in header menu
- removed styling for demo button
- added back to header navigation as menu item

**Additional note**
After implementing its needed to add Demo into menu in WP.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#514
