### PR TITLE
[503] fix: allowing click on whole play button in vertical video box

### DIFF
--- a/assets/scripts/app/custom_lightbox_youtube.js
+++ b/assets/scripts/app/custom_lightbox_youtube.js
@@ -4,10 +4,27 @@
     <strong>See it in Action</strong>
   </a>
 */
+const videoVertical = document.querySelectorAll(
+	'[class*="Block--video__vertical"] [data-ytid]'
+);
+
+if ( videoVertical.length > 0 ) {
+	videoVertical.forEach( ( video ) => {
+		const playBtn = document.createElement( 'span' );
+
+		Object.assign( playBtn, {
+			className: 'playBtn',
+		} );
+		playBtn.dataset.ytid = video.dataset.ytid;
+		video.closest( '.elementor-widget-container' ).insertAdjacentElement( 'afterbegin', playBtn );
+	} );
+}
+
+const body = document.querySelector( 'body' );
+
 const modalVideo = document.querySelectorAll(
 	'[data-lightbox="youtube"], [class*="Block--video"] [data-ytid]'
 );
-const body = document.querySelector( 'body' );
 
 function loadYouTubeModal( yt, target ) {
 	const videoID = yt.dataset.ytid;

--- a/assets/styles/components/_BlockVideo.scss
+++ b/assets/styles/components/_BlockVideo.scss
@@ -285,7 +285,7 @@ $positions: ("left", "right");
 
 				}
 
-				@media (min-width: $breakpoint-desktop-hd + 1px) {
+				@media (min-width: ($breakpoint-desktop-hd + 1px)) {
 
 					.wrapper {
 						#{$pos}: auto;
@@ -296,7 +296,7 @@ $positions: ("left", "right");
 		}
 	}
 
-	@media (min-width: $breakpoint-desktop-hd + 1px) {
+	@media (min-width: ($breakpoint-desktop-hd + 1px)) {
 
 		.youtube__loader,
 		.elementor-custom-embed-image-overlay {
@@ -327,7 +327,7 @@ $positions: ("left", "right");
 	.videoTitle {
 		position: absolute;
 		pointer-events: none;
-		z-index: 1;
+		z-index: 2;
 		width: 100%;
 		padding: 2em;
 		top: 4em;
@@ -377,7 +377,7 @@ $positions: ("left", "right");
 				display: none;
 			}
 
-			@media (min-width: $breakpoint-tablet + 1px) {
+			@media (min-width: ($breakpoint-tablet + 1px)) {
 
 				@include posZero;
 				position: absolute;
@@ -399,20 +399,21 @@ $positions: ("left", "right");
 			position: relative;
 			overflow: visible;
 			border-radius: $border-radius-16;
+			z-index: 1;
 
-			&::before {
+			.playBtn {
 
 				position: absolute;
 				width: 10em;
 				height: 0;
 				padding-bottom: 20%;
-				content: "";
 				background: url(../images/play_videoHorizontal.svg) center center no-repeat;
 				background-size: contain;
 				bottom: 0;
 				left: 50%;
 				transform: translate(-50%, calc(50% - 0.15em));
-				z-index: 1;
+				z-index: 3;
+				cursor: pointer;
 			}
 
 			&::after {

--- a/assets/styles/elements/_YoutubeLoader.scss
+++ b/assets/styles/elements/_YoutubeLoader.scss
@@ -25,7 +25,7 @@
 	}
 
 	iframe.youtube__loader--embed {
-		position: absolute;
+		position: fixed;
 		top: -30px;
 		z-index: 2;
 		opacity: 0;

--- a/templates/head.php
+++ b/templates/head.php
@@ -1,7 +1,7 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, shrink-to-fit=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://cdn.liveagent.com">


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Allowing click on whole play button in vertical video box

**Testing instructions**
Go to https://www.liveagent.com/ticketing-software/ and check if clicking on orange Play buttons is working correctly – it should open modal Youtube box regardless of where you click on it. Clicking on image should work too. It shouldn't cause to load video twice (creating two sound streams running)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#503
