### PR TITLE
[521] fix: changed scroll event to intersection observer to avoid jumping icon

### DIFF
--- a/assets/scripts/custom/pricing.js
+++ b/assets/scripts/custom/pricing.js
@@ -219,7 +219,7 @@ function sticky( stickyTable ) {
 								} );
 							return;
 						}
-						if ( entry.boundingClientRect.top > 120 ) {
+						if ( entry.boundingClientRect.top > 96 ) {
 							header.classList.remove( 'ComparePlans__fixed' );
 							document
 								.querySelectorAll( '.ComparePlans__header__icon' )
@@ -235,7 +235,7 @@ function sticky( stickyTable ) {
 						}
 					},
 					{
-						rootMargin: `0px 0px -${ window.innerHeight - 120 }px 0px`,
+						rootMargin: `0px 0px -${ window.innerHeight - 96 }px 0px`,
 					}
 				);
 

--- a/assets/scripts/custom/pricing.js
+++ b/assets/scripts/custom/pricing.js
@@ -1,3 +1,5 @@
+/* global IntersectionObserver */
+
 const mainHeaderHeight = document.querySelector( '.Header' ).clientHeight;
 
 /* Expand table */
@@ -198,37 +200,47 @@ function sticky( stickyTable ) {
 			const header = document.querySelector(
 				'#ComparePlans__table-head-wrap'
 			);
-			const posTop = stickyTop.top + window.pageYOffset + 80;
 
-			window.addEventListener( 'scroll', () => {
-				if ( window.scrollY >= posTop ) {
-					header.classList.add( 'ComparePlans__fixed' );
-					document
-						.querySelectorAll( '.ComparePlans__header__icon' )
-						.forEach( ( element ) => {
-							const icon = element;
-							icon.classList.add(
-								'ComparePlans__header-image--hide'
-							);
-							icon.classList.remove(
-								'ComparePlans__header-image--show'
-							);
-						} );
-				} else {
-					header.classList.remove( 'ComparePlans__fixed' );
-					document
-						.querySelectorAll( '.ComparePlans__header__icon' )
-						.forEach( ( element ) => {
-							const icon = element;
-							icon.classList.remove(
-								'ComparePlans__header-image--hide'
-							);
-							icon.classList.add(
-								'ComparePlans__header-image--show'
-							);
-						} );
-				}
-			} );
+			if ( 'IntersectionObserver' in window ) {
+				const pricingHeaderObserver = new IntersectionObserver(
+					( [ entry ] ) => {
+						if ( entry.isIntersecting ) {
+							header.classList.add( 'ComparePlans__fixed' );
+							document
+								.querySelectorAll( '.ComparePlans__header__icon' )
+								.forEach( ( element ) => {
+									const icon = element;
+									icon.classList.add(
+										'ComparePlans__header-image--hide'
+									);
+									icon.classList.remove(
+										'ComparePlans__header-image--show'
+									);
+								} );
+							return;
+						}
+						if ( entry.boundingClientRect.top > 120 ) {
+							header.classList.remove( 'ComparePlans__fixed' );
+							document
+								.querySelectorAll( '.ComparePlans__header__icon' )
+								.forEach( ( element ) => {
+									const icon = element;
+									icon.classList.remove(
+										'ComparePlans__header-image--hide'
+									);
+									icon.classList.add(
+										'ComparePlans__header-image--show'
+									);
+								} );
+						}
+					},
+					{
+						rootMargin: `0px 0px -${ window.innerHeight - 120 }px 0px`,
+					}
+				);
+
+				pricingHeaderObserver.observe( header );
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
changed scroll event to intersection observer to avoid jumping icon

**Testing instructions**
When you click on Show All Features in pricing, icons in a table header should no longer „jump“ after scrolling to position

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#521
