### PR TITLE
fix: faq links color from default to primary color

### DIFF
--- a/assets/styles/components/_ExtraFaq.scss
+++ b/assets/styles/components/_ExtraFaq.scss
@@ -101,6 +101,17 @@
 						display: none;
 					}
 				}
+
+				a:not(.Button) {
+
+					@include color(color, primary-color);
+
+					&:active,
+					&:focus,
+					&:hover {
+						text-decoration: underline;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed color of links in FAQ section from default to primary

**Testing instructions**
Check links color on page (primary FAQ section on demo page)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#606
