### PR TITLE
fix: fixed link on compare-plans button

### DIFF
--- a/lib/shortcodes/block-pricing.php
+++ b/lib/shortcodes/block-pricing.php
@@ -152,7 +152,7 @@ function ms_block_pricing( $atts ) {
 		</div>
 	</div>
 	<div class="BlockPricing__button">
-		<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full">
+		<a href="<?php _e( '/pricing/', 'ms' ); ?>" class="Button Button--full">
 			<span><?php _e( 'Compare plans', 'ms' ); ?></span>
 			<span class="ButtonPricing--arrow">&#8594;</span>
 		</a>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Hotfix for "compare-plans" button. Changed link

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
