### PR TITLE
[586] fix: sliders images loading at once if slider is in viewport

### DIFF
--- a/assets/scripts/custom/slider.js
+++ b/assets/scripts/custom/slider.js
@@ -1,4 +1,5 @@
 /* global Splide, IntersectionObserver */
+
 const direction = () => {
 	return document.documentElement.dir;
 };
@@ -10,11 +11,11 @@ const thisSliders = document.querySelectorAll(
 /* Testimonials Slider */
 if ( thisSliders.length > 0 ) {
 	thisSliders.forEach( ( slider ) => {
-		new Splide( slider, {
+		const testimonialSlider = new Splide( slider, {
 			type: 'loop',
 			autoplay: true,
 			direction: direction(),
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			speed: 300,
 			easing: 'linear',
 			fixedWidth: 'calc(50% - 70px)',
@@ -33,7 +34,25 @@ if ( thisSliders.length > 0 ) {
 					arrows: false,
 				},
 			},
-		} ).mount();
+		} );
+
+		if ( 'IntersectionObserver' in window && thisSliders.length > 0 ) {
+			const testimonialSliderObserver = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							testimonialSlider.mount( );
+
+							const sliderObject = entry.target;
+							testimonialSliderObserver.unobserve( sliderObject );
+						}
+					} );
+				}
+			);
+			thisSliders.forEach( ( sliderObject ) => {
+				testimonialSliderObserver.observe( sliderObject );
+			} );
+		}
 	} );
 }
 
@@ -54,7 +73,7 @@ if ( homeVertical.length > 0 ) {
 			type: 'loop',
 			direction: 'ttb',
 			autoplay: true,
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			height: '44.5rem',
 			fixedHeight: '13.5rem',
 			speed: 500,
@@ -119,7 +138,7 @@ if ( homeVertical.length > 0 ) {
 				( entries ) => {
 					entries.forEach( ( entry ) => {
 						if ( entry.isIntersecting ) {
-							testimonials.mount();
+							testimonials.mount( );
 
 							const sliderObject = entry.target;
 							testimonialsObserver.unobserve( sliderObject );
@@ -148,7 +167,7 @@ if ( homeHorizontal.length > 0 ) {
 		} );
 		const horizontalSlider = new Splide( slider, {
 			type: 'loop',
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			autoplay: true,
 			fixedWidth: '27.65rem',
 			height: '15.5em',
@@ -187,7 +206,23 @@ if ( homeHorizontal.length > 0 ) {
 			}
 		} );
 
-		horizontalSlider.mount();
+		if ( 'IntersectionObserver' in window && homeHorizontal.length > 0 ) {
+			const horizontalSliderObserver = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							horizontalSlider.mount( );
+
+							const sliderObject = entry.target;
+							horizontalSliderObserver.unobserve( sliderObject );
+						}
+					} );
+				}
+			);
+			homeVertical.forEach( ( sliderObject ) => {
+				horizontalSliderObserver.observe( sliderObject );
+			} );
+		}
 	} );
 }
 
@@ -197,9 +232,10 @@ const gutenSliders = document.querySelectorAll(
 );
 if ( gutenSliders.length > 0 ) {
 	gutenSliders.forEach( ( slider ) => {
-		new Splide( slider, {
+		const gutenSlider = new Splide( slider, {
 			type: 'loop',
 			autoplay: false,
+			lazyload: 'sequential',
 			direction: direction(),
 			speed: 300,
 			easing: 'linear',
@@ -217,7 +253,25 @@ if ( gutenSliders.length > 0 ) {
 					arrows: false,
 				},
 			},
-		} ).mount();
+		} );
+
+		if ( 'IntersectionObserver' in window && gutenSliders.length > 0 ) {
+			const gutenSliderObserver = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							gutenSlider.mount( );
+
+							const sliderObject = entry.target;
+							gutenSliderObserver.unobserve( sliderObject );
+						}
+					} );
+				}
+			);
+			thisSliders.forEach( ( sliderObject ) => {
+				gutenSliderObserver.observe( sliderObject );
+			} );
+		}
 	} );
 }
 
@@ -265,7 +319,7 @@ if ( customerbubbles.length > 0 ) {
 			type: 'loop',
 			direction: 'ttb',
 			autoplay: true,
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			height: '29em',
 			speed: 500,
 			interval: 5000,
@@ -368,11 +422,11 @@ const smallPhotoSlider = document.querySelectorAll( '.SmallPhoto__slider' );
 
 if ( smallPhotoSlider.length > 0 ) {
 	smallPhotoSlider.forEach( ( slider ) => {
-		new Splide( slider, {
+		const smallPhotos = new Splide( slider, {
 			type: 'loop',
 			autoplay: true,
 			direction: direction(),
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			speed: 300,
 			easing: 'linear',
 			perPage: 3,
@@ -386,7 +440,25 @@ if ( smallPhotoSlider.length > 0 ) {
 					pagination: true,
 				},
 			},
-		} ).mount();
+		} );
+
+		if ( 'IntersectionObserver' in window && smallPhotoSlider.length > 0 ) {
+			const smallPhotosObserver = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							smallPhotos.mount( );
+
+							const sliderObject = entry.target;
+							smallPhotosObserver.unobserve( sliderObject );
+						}
+					} );
+				}
+			);
+			smallPhotoSlider.forEach( ( sliderObject ) => {
+				smallPhotosObserver.observe( sliderObject );
+			} );
+		}
 	} );
 }
 
@@ -394,11 +466,11 @@ const logosSlider = document.querySelectorAll( '.Logos__slider' );
 
 if ( logosSlider.length > 0 ) {
 	logosSlider.forEach( ( slider ) => {
-		new Splide( slider, {
+		const logos = new Splide( slider, {
 			type: 'loop',
 			autoplay: true,
 			direction: direction(),
-			lazyLoad: 'nearby',
+			lazyLoad: 'sequential',
 			speed: 600,
 			interval: 8000,
 			easing: 'linear',
@@ -415,6 +487,24 @@ if ( logosSlider.length > 0 ) {
 					pagination: true,
 				},
 			},
-		} ).mount();
+		} );
+
+		if ( 'IntersectionObserver' in window && logosSlider.length > 0 ) {
+			const logosObserver = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							logos.mount( );
+
+							const sliderObject = entry.target;
+							logosObserver.unobserve( sliderObject );
+						}
+					} );
+				}
+			);
+			logosSlider.forEach( ( sliderObject ) => {
+				logosObserver.observe( sliderObject );
+			} );
+		}
 	} );
 }

--- a/assets/scripts/custom/slider.js
+++ b/assets/scripts/custom/slider.js
@@ -219,7 +219,7 @@ if ( homeHorizontal.length > 0 ) {
 					} );
 				}
 			);
-			homeVertical.forEach( ( sliderObject ) => {
+			homeHorizontal.forEach( ( sliderObject ) => {
 				horizontalSliderObserver.observe( sliderObject );
 			} );
 		}

--- a/lib/shortcodes/customers-bubble.php
+++ b/lib/shortcodes/customers-bubble.php
@@ -36,7 +36,9 @@ function ms_customersbubble( $atts ) {
 			<li <?php post_class( 'splide__slide white--bubble white--bubble--quote' ); ?>>
 				<div class="slide__inn elementor-widget-container">
 					<?= get_the_content(); // @codingStandardsIgnoreLine ?>
-					<div class="white--bubble--quote__logo"><?= wp_get_attachment_image( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_logo', true ), 'testimonials_box_logo' ) ?></div>
+					<div class="white--bubble--quote__logo">
+						<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_logo', true ), 'testimonials_box_logo' ) ); ?>" alt="<?php the_title(); ?>" />
+					</div>
 				</div>
 			</li>
 

--- a/lib/shortcodes/slider-testimonials-custom.php
+++ b/lib/shortcodes/slider-testimonials-custom.php
@@ -40,7 +40,7 @@ function ms_slidertestimonials_custom( $atts ) {
 								}
 								?>
 								">
-									<?= wp_get_attachment_image( get_post_meta( get_the_ID(), 'mb_alternatives_mb_alternatives_person', true ), 'logo_thumbnail' ) ?>
+									<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( get_post_meta( get_the_ID(), 'mb_alternatives_mb_alternatives_person', true ), 'logo_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
 								</div>
 								<b class="SliderTestimonials__slider__header__person__name"><?php the_title(); ?></b>
 								<div class="SliderTestimonials__slider__header__text">
@@ -56,7 +56,7 @@ function ms_slidertestimonials_custom( $atts ) {
 								<p><?php the_content(); ?></p>
 							</div>
 							<div class="SliderTestimonials__slider__header__text__logo">
-								<?php the_post_thumbnail( 'logo_thumbnail' ); ?>
+								<img data-splide-lazy="<?= esc_url( the_post_thumbnail_url( 'logo_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
 							</div>
 						</div>
 					</li>

--- a/lib/shortcodes/slider-testimonials.php
+++ b/lib/shortcodes/slider-testimonials.php
@@ -26,13 +26,13 @@ function ms_slidertestimonials() {
 						<div class="slide__inn">
 							<div class="SliderTestimonials__slider__header">
 								<div class="SliderTestimonials__slider__header__photo">
-									<?= wp_get_attachment_image( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_photo', true ), 'logo_small_thumbnail' ) ?>
+									<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_photo', true ), 'logo_small_thumbnail' ) ) ?>" alt="<?php the_title(); ?>" />
 								</div>
 								<div class="SliderTestimonials__slider__header__text">
 									<p class="SliderTestimonials__slider__header__text__name"><?= esc_html( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_name', true ) ) ?></p>
 									<p class="SliderTestimonials__slider__header__text__position"><?= esc_html( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_position', true ) ) ?></p>
 									<div class="SliderTestimonials__slider__header__text__logo">
-										<?= wp_get_attachment_image( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_logo', true ), 'logo_thumbnail' ) ?>
+										<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( get_post_meta( get_the_ID(), 'mb_testimonials_mb_testimonials_logo', true ), 'logo_thumbnail' ) ) ?>" alt="<?php the_title(); ?>" />
 									</div>
 								</div>
 							</div>

--- a/lib/shortcodes/small-photo-slider.php
+++ b/lib/shortcodes/small-photo-slider.php
@@ -56,7 +56,7 @@ function ms_small_photo_slider( $atts ) {
 									</svg>
 									<?= esc_html( $atts['zoomin'] ); ?>
 								</span>
-								<img style="opacity: 0; transition: opacity 0.5s ease 0s;" data-lasrc="<?php the_post_thumbnail_url( 'person_thumbnail' ); ?>" alt="<?php the_title(); ?>" />
+								<img data-splide-lazy="<?php the_post_thumbnail_url( 'person_thumbnail' ); ?>" alt="<?php the_title(); ?>" />
 								<?php if ( $atts['showtitle'] !== 'false' ) {/* @codingStandardsIgnoreLine */?>
 									<span class="SmallPhoto__slider__desc"><?php the_title(); ?></span>
 									<?php

--- a/lib/shortcodes/voip-partners.php
+++ b/lib/shortcodes/voip-partners.php
@@ -37,7 +37,7 @@ function ms_voip_partners() {
 					?>
 		<li class="VoIP__partner Logo__slide splide__slide">
 			<a href="<?= esc_url( get_the_permalink() ); ?>">
-					<?php the_post_thumbnail( 'archive_thumbnail' ); ?>
+				<img data-splide-lazy="<?= esc_url(  wp_get_attachment_image_url( $attachment_id = $post_thumbnail_id, 'archive_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
 			</a>
 		</li>
 

--- a/lib/shortcodes/voip-partners.php
+++ b/lib/shortcodes/voip-partners.php
@@ -37,7 +37,7 @@ function ms_voip_partners() {
 					?>
 		<li class="VoIP__partner Logo__slide splide__slide">
 			<a href="<?= esc_url( get_the_permalink() ); ?>">
-				<img data-splide-lazy="<?= esc_url(  wp_get_attachment_image_url( $attachment_id = $post_thumbnail_id, 'archive_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
+				<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( $attachment_id = $post_thumbnail_id, 'archive_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
 			</a>
 		</li>
 

--- a/lib/shortcodes/voip-partners.php
+++ b/lib/shortcodes/voip-partners.php
@@ -37,7 +37,7 @@ function ms_voip_partners() {
 					?>
 		<li class="VoIP__partner Logo__slide splide__slide">
 			<a href="<?= esc_url( get_the_permalink() ); ?>">
-				<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( $attachment_id = $post_thumbnail_id, 'archive_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
+				<img data-splide-lazy="<?= esc_url( wp_get_attachment_image_url( $post_thumbnail_id, 'archive_thumbnail' ) ); ?>" alt="<?php the_title(); ?>" />
 			</a>
 		</li>
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Sliders images loading at once if slider is in viewport.
This fixes Google screaming about long loading times when images in sliders were lazy loaded right before showing up on next slide move.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
