### PR TITLE
[571] style: fix for value boxes on mobile and tablet viewport

### DIFF
--- a/assets/styles/components/_Block.scss
+++ b/assets/styles/components/_Block.scss
@@ -256,8 +256,11 @@
 					align-items: center;
 					width: 38%;
 					padding: 2.75em 2.5em;
-					background: url(../images/value-boxes-path.svg) right center no-repeat;
-					background-size: auto 100%;
+
+					@media (min-width: $breakpoint-tablet-landscape) {
+						background: url(../images/value-boxes-path.svg) right center no-repeat;
+						background-size: auto 100%;
+					}
 
 					strong {
 

--- a/assets/styles/components/_Block.scss
+++ b/assets/styles/components/_Block.scss
@@ -216,7 +216,7 @@
 
 			@media (max-width: ($breakpoint-tablet - 1px)) {
 				order: 2 !important;
-				width: 50% !important;
+				width: 100% !important;
 				margin-top: 75px !important;
 			}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Value boxes are now full width on mobile resolution
Removed background on each box for tablet resolution

**Testing instructions**
Check the design on [this](http://liveagent.local) page.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#571