### PR TITLE
[655] fix: removed dropcap generator, moved to :first-letter css style

### DIFF
--- a/assets/styles/layouts/_BlogPost.scss
+++ b/assets/styles/layouts/_BlogPost.scss
@@ -276,7 +276,7 @@
 
 		.Content {
 
-			p span.dropcap {
+			> p:first-of-type::first-letter {
 				font-size: 100px;
 				line-height: 75px;
 				font-weight: 700;

--- a/assets/styles/layouts/_Gutenberg.scss
+++ b/assets/styles/layouts/_Gutenberg.scss
@@ -4,14 +4,6 @@
 	margin: 30px 0;
 	padding: 30px 0;
 
-	span.dropcap {
-		font-size: 16px !important;
-		line-height: 24px !important;
-		font-weight: 400 !important;
-		float: none !important;
-		margin-right: 0 !important;
-	}
-
 	&--yes {
 
 		@include color(background-color, newsletter-background);

--- a/functions/content-filters.php
+++ b/functions/content-filters.php
@@ -176,47 +176,17 @@ function add_drop_caps( $content ) {
 	global $post;
 
 	if ( ! empty( $post ) && 'post' === $post->post_type ) {
-		$match = get_matches( '/\<p\>[A-Z]/i', $content, true );
-
+		$match = '/\<p\>(\<a.+?\>)?([A-Z])([^<]+)(\<\/a\>)?/i';
 		if ( ! empty( $match ) ) {
-			$letter  = str_replace( '<p>', '', $match );
-			$dropcap = '<p><span class="dropcap">' . $letter . '</span>';
-			$content = str_replace_once( $match, $dropcap, $content );
+			$dropcap = '<p>$1<span class="dropcap">$2</span>$3$4';
+			$content = preg_replace( $match, $dropcap, $content, 1 );
 		}
 	}
 
 	return $content;
 }
-add_filter( 'the_content', 'add_drop_caps', 30 );
-add_filter( 'the_excerpt', 'add_drop_caps', 30 );
-
-function get_matches( $p, $s, $first_value = false, $n = 0 ) {
-	$ok = preg_match_all( $p, $s, $matches );
-
-	if ( ! $ok ) {
-		return false;
-	} else {
-		if ( $first_value ) {
-			return $matches[ $n ][0];
-		} else {
-			return $matches[ $n ];
-		}
-	}
-}
-
-function str_replace_once( $search, $replace, $subject ) {
-	$first_char = strpos( $subject, $search );
-
-	if ( false !== $first_char ) {
-		$before_str = substr( $subject, 0, $first_char );
-		$after_str  = substr( $subject, $first_char + strlen( $search ) );
-
-		return $before_str . $replace . $after_str;
-	} else {
-		return $subject;
-	}
-}
-
+// add_filter( 'the_content', 'add_drop_caps', 30 );
+// add_filter( 'the_excerpt', 'add_drop_caps', 30 );
 
 /**
  * Changes default WordPress gutenberg button to LA style buttn

--- a/lib/widgets/qu-howtos/src/scss/_howto.scss
+++ b/lib/widgets/qu-howtos/src/scss/_howto.scss
@@ -1,5 +1,13 @@
 .qu-HowTo {
 	margin-bottom: 3em;
+
+	.Content > &:first-child > p:first-of-type::first-letter {
+		font-size: 100px;
+		line-height: 75px;
+		font-weight: 700;
+		float: left;
+		margin-right: 10px;
+	}
 }
 
 .qu-HowToItem {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed dropcap generator, moved to :first-letter css style

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#655
