### PR TITLE
fix: change old cdn to www cdns url

### DIFF
--- a/apps/typing-test/src/style.css
+++ b/apps/typing-test/src/style.css
@@ -242,15 +242,15 @@ textarea:focus,
 }
 
 .TypingTest__icon__test-duration__1min {
-  background: url("https://cdn.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/1min.png") no-repeat;
+  background: url("https://www.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/1min.png") no-repeat;
 }
 
 .TypingTest__icon__test-duration__3min {
-  background: url("https://cdn.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/3min.png") no-repeat;
+  background: url("https://www.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/3min.png") no-repeat;
 }
 
 .TypingTest__icon__test-duration__5min {
-  background: url("https://cdn.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/5min.png") no-repeat;
+  background: url("https://www.liveagent.com/app/themes/liveagent/apps/typing-test/build/public/assets/5min.png") no-repeat;
 }
 
 .TypingTest__statistic__graph {

--- a/lib/shortcodes/good-hands.php
+++ b/lib/shortcodes/good-hands.php
@@ -43,7 +43,7 @@ function ms_good_hands( $atts ) {
 									<div class="Reviews__items">
 										<div class="Reviews__items__item">
 											<a href="<?php _e( '/awards/', 'ms' ); ?>" title="G2 Crowd">
-												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://cdn.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="G2 Crowd">
+												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://www.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="G2 Crowd">
 											</a>
 											<div class="Reviews__items__item__stars">
 												<span class="Reviews__items__item__stars__item"></span>
@@ -55,7 +55,7 @@ function ms_good_hands( $atts ) {
 										</div>
 										<div class="Reviews__items__item">
 											<a href="<?php _e( '/awards/', 'ms' ); ?>" title="Trustpilot">
-												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://cdn.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="Trustpilot">
+												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://www.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="Trustpilot">
 											</a>
 											<div class="Reviews__items__item__stars">
 												<span class="Reviews__items__item__stars__item"></span>
@@ -67,7 +67,7 @@ function ms_good_hands( $atts ) {
 										</div>
 										<div class="Reviews__items__item">
 											<a href="<?php _e( '/awards/', 'ms' ); ?>" title="GetApp">
-												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://cdn.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="GetApp">
+												<img style="opacity: 0; transition: opacity .5s" data-lasrc="https://www.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="GetApp">
 											</a>
 											<div class="Reviews__items__item__stars">
 												<span class="Reviews__items__item__stars__item"></span>

--- a/lib/shortcodes/gutenberg-awards.php
+++ b/lib/shortcodes/gutenberg-awards.php
@@ -24,7 +24,7 @@ function ms_gutenberg_awards() {
 						<div class="elementor-widget-image">
 							<div class="elementor-widget-container">
 								<div class="elementor-image">
-									<img src="https://cdn.liveagent.com/app/uploads/2020/03/badges.png" alt="<?php _e( 'Badges', 'ms' ); ?>" loading="lazy">
+									<img src="https://www.liveagent.com/app/uploads/2020/03/badges.png" alt="<?php _e( 'Badges', 'ms' ); ?>" loading="lazy">
 								</div>
 							</div>
 						</div>

--- a/lib/shortcodes/gutenberg-reference.php
+++ b/lib/shortcodes/gutenberg-reference.php
@@ -12,7 +12,7 @@ function ms_gutenberg_reference() {
 						<div class="elementor-widget-image">
 							<div class="elementor-widget-container">
 								<div class="elementor-image">
-									<img src="https://cdn.liveagent.com/app/uploads/2019/11/komora.png" alt="<?php _e( 'Peter Komornik', 'ms' ); ?>" loading="lazy">
+									<img src="https://www.liveagent.com/app/uploads/2019/11/komora.png" alt="<?php _e( 'Peter Komornik', 'ms' ); ?>" loading="lazy">
 								</div>
 							</div>
 						</div>
@@ -29,7 +29,7 @@ function ms_gutenberg_reference() {
 							</div>
 							<div class="elementor-widget-image">
 								<div class="elementor-image">
-									<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_slido_black.svg" alt="logo slido black" loading="lazy">
+									<img src="https://www.liveagent.com/app/uploads/2019/11/logo_slido_black.svg" alt="logo slido black" loading="lazy">
 								</div>
 							</div>
 						</div>

--- a/lib/shortcodes/gutenberg-reviews.php
+++ b/lib/shortcodes/gutenberg-reviews.php
@@ -8,7 +8,7 @@ function ms_gutenberg_reviews() {
 			<div class="Reviews__items">
 					<div class="Reviews__items__item">
 							<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'G2 Crowd', 'ms' ); ?>">
-									<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>">
+									<img src="https://www.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>">
 							</a>
 							<div class="Reviews__items__item__stars">
 									<span class="Reviews__items__item__stars__item"></span>
@@ -20,7 +20,7 @@ function ms_gutenberg_reviews() {
 					</div>
 					<div class="Reviews__items__item">
 							<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'Trustpilot', 'ms' ); ?>">
-									<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="<?php _e( 'Trustpilot', 'ms' ); ?>">
+									<img src="https://www.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="<?php _e( 'Trustpilot', 'ms' ); ?>">
 							</a>
 							<div class="Reviews__items__item__stars">
 									<span class="Reviews__items__item__stars__item"></span>
@@ -32,7 +32,7 @@ function ms_gutenberg_reviews() {
 					</div>
 					<div class="Reviews__items__item">
 							<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'GetApp', 'ms' ); ?>">
-									<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="<?php _e( 'GetApp', 'ms' ); ?>">
+									<img src="https://www.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="<?php _e( 'GetApp', 'ms' ); ?>">
 							</a>
 							<div class="Reviews__items__item__stars">
 									<span class="Reviews__items__item__stars__item"></span>

--- a/lib/shortcodes/reviews.php
+++ b/lib/shortcodes/reviews.php
@@ -7,7 +7,7 @@ function ms_reviews() {
 	<div class="Reviews__items">
 		<div class="Reviews__items__item">
 			<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'G2 Crowd', 'ms' ); ?>">
-				<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>">
+				<img src="https://www.liveagent.com/app/uploads/2019/11/logo_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>">
 			</a>
 			<div class="Reviews__items__item__stars">
 				<span class="Reviews__items__item__stars__item"></span>
@@ -19,7 +19,7 @@ function ms_reviews() {
 		</div>
 		<div class="Reviews__items__item">
 			<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'Trustpilot', 'ms' ); ?>">
-				<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="<?php _e( 'Trustpilot', 'ms' ); ?>">
+				<img src="https://www.liveagent.com/app/uploads/2019/11/logo_trustpilot.svg" alt="<?php _e( 'Trustpilot', 'ms' ); ?>">
 			</a>
 			<div class="Reviews__items__item__stars">
 				<span class="Reviews__items__item__stars__item"></span>
@@ -31,7 +31,7 @@ function ms_reviews() {
 		</div>
 		<div class="Reviews__items__item">
 			<a href="<?php _e( '/awards/', 'ms' ); ?>" title="<?php _e( 'GetApp', 'ms' ); ?>">
-				<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="<?php _e( 'GetApp', 'ms' ); ?>">
+				<img src="https://www.liveagent.com/app/uploads/2019/11/logo_getapp.svg" alt="<?php _e( 'GetApp', 'ms' ); ?>">
 			</a>
 			<div class="Reviews__items__item__stars">
 				<span class="Reviews__items__item__stars__item"></span>

--- a/template-academy-header.php
+++ b/template-academy-header.php
@@ -104,7 +104,7 @@
 									<div class="elementor-image">
 										<img style="opacity: 0; transition: opacity 0.5s ease 0s;" class="attachment-large size-large"
 											alt="<?php _e( 'Header Animation', 'ms' ); ?>" loading="lazy" height="100" width="100"
-											data-lasrc="https://cdn.liveagent.com/app/uploads/2021/06/helpdesk-2.svg">
+											data-lasrc="https://www.liveagent.com/app/uploads/2021/06/helpdesk-2.svg">
 									</div>
 								</div>
 							</div>
@@ -113,7 +113,7 @@
 									<div class="elementor-image">
 										<img width="970" height="1024" style="opacity:0; transition: opacity 0.5s ease 0s;"
 											class="attachment-large size-large" alt="<?php _e( 'Helpdesk software', 'ms' ); ?>" loading="lazy"
-											data-lasrc="https://cdn.liveagent.com/app/uploads/2021/06/helpdesk_bg-970x1024.jpg"> </div>
+											data-lasrc="https://www.liveagent.com/app/uploads/2021/06/helpdesk_bg-970x1024.jpg"> </div>
 								</div>
 							</div>
 						</div>

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -105,7 +105,7 @@
 									<div class="elementor-image">
 										<img style="opacity: 0; transition: opacity 0.5s ease 0s;" class="attachment-large size-large"
 											alt="<?php _e( 'Header Animation', 'ms' ); ?>" loading="lazy" height="100" width="100"
-											data-lasrc="https://cdn.liveagent.com/app/uploads/2021/06/helpdesk-2.svg">
+											data-lasrc="https://www.liveagent.com/app/uploads/2021/06/helpdesk-2.svg">
 									</div>
 								</div>
 							</div>
@@ -114,7 +114,7 @@
 									<div class="elementor-image">
 										<img width="970" height="1024" style="opacity:0; transition: opacity 0.5s ease 0s;"
 											class="attachment-large size-large" alt="<?php _e( 'Helpdesk software', 'ms' ); ?>" loading="lazy"
-											data-lasrc="https://cdn.liveagent.com/app/uploads/2021/06/helpdesk_bg-970x1024.jpg"> </div>
+											data-lasrc="https://www.liveagent.com/app/uploads/2021/06/helpdesk_bg-970x1024.jpg"> </div>
 								</div>
 							</div>
 						</div>

--- a/template-demo.php
+++ b/template-demo.php
@@ -13,19 +13,19 @@
 		<div class="slider splide">
 			<div class="splide__track">
 				<div class="splide__list">
-					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_demo_michaela.jpg);">
+					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_demo_michaela.jpg);">
 						<div class="FullScreen__sidebar__item__text">
 						<?php _e( '<p>"Do you know what is best about LiveAgent? All the live chat benefits? Providing real-time support? Having all the communication under the same roof...? Maybe I could go on and on about all the features we have but let me show you what we have during our demo presentation and decide for yourself!"</p><p>Michael Gombarova, <strong>Sales Manager</strong></p>', 'ms' ); ?>
 						</div>
 					</div>
 
-					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_demo_tomas.jpg);">
+					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_demo_tomas.jpg);">
 						<div class="FullScreen__sidebar__item__text">
 						<?php _e( '<p>"Lumberjack shirt? Check! Laptop for the demo? Check! Notepad for ideas? Check! Are you ready?"</p><p>Tomas Varga, <strong>Sales Manager</strong></p>', 'ms' ); ?>
 						</div>
 					</div>
 
-					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_demo_andrej.jpg);">
+					<div class="splide__slide FullScreen__sidebar__item FullScreen__sidebar__item--demo" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_demo_andrej.jpg);">
 						<div class="FullScreen__sidebar__item__text">
 						<?php _e( '<p>"Approach each customer with the idea of helping him or her to solve a problem or achieve a goal, not of selling a product or service." – Brian Tracy</p><p>Andrej Saxon, <strong>Sales Manager</strong></p>', 'ms' ); ?>
 						</div>

--- a/template-free-account.php
+++ b/template-free-account.php
@@ -10,10 +10,10 @@
 	</a>
 
 	<div class="FullScreen__sidebar">
-		<div class="FullScreen__sidebar__item" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
+		<div class="FullScreen__sidebar__item" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
 			<div class="FullScreen__sidebar__item__text">
 				<?php _e( '<p>"LiveAgent combines excellent live chat, ticketing and automation that allow us to provide exceptional support to our customers."</p><p>Peter Komornik, <strong>CEO</strong></p>', 'ms' ); ?>
-				<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
+				<img src="https://www.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
 			</div>
 		</div>
 	</div>

--- a/template-trial-redesign.php
+++ b/template-trial-redesign.php
@@ -11,13 +11,13 @@
 	</a>
 
 	<div class="Trial__container">
-		<div class="Trial__sidebar" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
+		<div class="Trial__sidebar" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
 			<a href="<?= esc_url( home_url( '/', 'relative' ) ); ?>" class="Trial__logo__top--inn" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Trial Logo'])">
 				<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/logo_liveagent_black.svg" alt="<?php bloginfo( 'name' ); ?>">
 			</a>
 			<div class="Trial__sidebar__text">
 				<?php _e( '<p><em>"LiveAgent combines excellent live chat, ticketing and automation that allow us to provide exceptional support to our customers."</em></p><p>Peter Komornik, <strong>CEO</strong></p>', 'ms' ); ?>
-				<img class="Trial__sidebar__logo" src="https://cdn.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
+				<img class="Trial__sidebar__logo" src="https://www.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
 			</div>
 		</div>
 		<div class="Trial__main">

--- a/template-trial.php
+++ b/template-trial.php
@@ -10,10 +10,10 @@
 	</a>
 
 	<div class="FullScreen__sidebar">
-		<div class="FullScreen__sidebar__item" style="background-image: url(https://cdn.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
+		<div class="FullScreen__sidebar__item" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
 			<div class="FullScreen__sidebar__item__text">
 				<?php _e( '<p>"LiveAgent combines excellent live chat, ticketing and automation that allow us to provide exceptional support to our customers."</p><p>Peter Komornik, <strong>CEO</strong></p>', 'ms' ); ?>
-				<img src="https://cdn.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
+				<img src="https://www.liveagent.com/app/uploads/2019/11/logo_slido_white.svg" alt="<?php _e( 'Review', 'ms' ); ?>">
 			</div>
 		</div>
 	</div>

--- a/templates/head.php
+++ b/templates/head.php
@@ -4,7 +4,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://cdn.liveagent.com">
 	<link rel="preconnect" href="https://www.googletagmanager.com">
 	<link rel="preconnect" href="https://analytics.qualityunit.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Change old CDN to WWW urls. `cdn.liveagent.com` is no more supported.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
