### PR TITLE
fix: changed font weight on pricing tags

### DIFF
--- a/assets/styles/components/_BlockPricing.scss
+++ b/assets/styles/components/_BlockPricing.scss
@@ -95,7 +95,7 @@
 			padding: 0.5em 1.5em;
 			border-radius: 50px;
 			font-size: 12px;
-			font-weight: 500;
+			font-weight: $font-weight-semi;
 			line-height: $line-height-default;
 			font-family: $font-secondary;
 			text-align: center;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed font weight on tags in context of https://github.com/QualityUnit/web-issues/issues/494 where was an error in design

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x]  I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
