### PR TITLE
[734] fix: remove schema.org fix

### DIFF
--- a/functions/content-filters.php
+++ b/functions/content-filters.php
@@ -432,25 +432,3 @@ function elementor_pros_cons( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'elementor_pros_cons', 9999 );
-
-function change_schema_hostname( $data ) {
-	$protocol = 'http:\/\/';
-	$hostname = 'www.liveagent.com';
-	
-	if ( isset( $_SERVER['HTTPS'] ) &&
-			( $_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1 ) || //@codingStandardsIgnoreLine
-			isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) &&
-			$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) { //@codingStandardsIgnoreLine
-		$protocol = 'https:\/\/';
-	}
-
-	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-		$hostname = $_SERVER['SERVER_NAME']; //@codingStandardsIgnoreLine
-	}
-
-	$json   = wp_json_encode( $data );
-	$output = preg_replace( '/http(s?):\\\\\/\\\\\/(www\.)?live.?agent\.(.+?)\//', $protocol . $hostname . '\/', $json );
-	return $output;
-}
-
-add_filter( 'wpseo_schema_graph', 'change_schema_hostname', 10, 2 );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
- remove schema.org fix

_Note: The function is generating tons of PHP Warning with newest Yoast SEO_ `PHP Warning: Invalid argument supplied for foreach() in /var/www/html/web/app/plugins/wordpress-seo/src/generators/schema-generator.php on line 231`

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#734
