### PR TITLE
[953] hide images on mobile with urlslab class

### DIFF
--- a/template-academy-header.php
+++ b/template-academy-header.php
@@ -102,7 +102,7 @@
 					</div>
 					<div class="elementor-column heroHeadline--bg">
 						<div class="elementor-widget-wrap">
-							<div class="animation elementor-widget elementor-widget-image">
+							<div class="animation elementor-widget elementor-widget-image urlslab-min-width-1024">
 								<div class="elementor-widget-container">
 									<div class="elementor-image">
 										<img class="attachment-large size-large"
@@ -111,7 +111,7 @@
 									</div>
 								</div>
 							</div>
-							<div class="elementor-widget-image">
+							<div class="elementor-widget-image urlslab-min-width-768">
 								<div class="elementor-widget-container">
 									<div class="elementor-image">
 										<img width="970" height="1024"

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -97,14 +97,14 @@
 						</div>
 						<div class="elementor-column heroHeadline--bg">
 							<div class="elementor-widget-wrap elementor-element-populated">
-								<div class="animation elementor-widget elementor-widget-image">
+								<div class="animation elementor-widget elementor-widget-image urlslab-min-width-1024">
 									<div class="elementor-widget-container">
 										<img class="attachment-large size-large"
 											 alt="<?php _e( 'Header Animation', 'ms' ); ?>" height="100" width="100"
 											 src="https://www.liveagent.com/app/uploads/2021/06/helpdesk-2.svg">
 									</div>
 								</div>
-								<div class="elementor-widget-image">
+								<div class="elementor-widget-image urlslab-min-width-768">
 									<div class="elementor-widget-container">
 										<img width="970" height="1024"
 											 class="attachment-large size-large" alt="<?php _e( 'Helpdesk software', 'ms' ); ?>"

--- a/template-trial-redesign.php
+++ b/template-trial-redesign.php
@@ -11,7 +11,7 @@
 	</a>
 
 	<div class="Trial__container">
-		<div class="Trial__sidebar" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
+		<div class="Trial__sidebar urlslab-min-width-1024" style="background-image: url(https://www.liveagent.com/app/uploads/2020/01/bg_trial.jpg);">
 			<a href="<?= esc_url( home_url( '/', 'relative' ) ); ?>" class="Trial__logo__top--inn" onclick="_paq.push(['trackEvent', 'Activity', 'Header', 'Trial Logo'])">
 				<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/logo_liveagent_black.svg" alt="<?php bloginfo( 'name' ); ?>" class="urlslab-skip-lazy">
 			</a>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added "urlslab-min-width" classes for hide images on mobile (mostly in hero sections).

**Testing instructions**
Check image loading on responsive.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#953
