### PR TITLE
fix: php memory allocation due to wp_query for whole posts content

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -31,6 +31,7 @@ define( 'THEME_VERSION', '1.6.11' );
 		'functions/components-imports.php', // Import CSS and JS for blocks or components on page
 		'functions/sideribbon-arrow.php', // Adds SVG with bookmark like ending
 		'functions/import-functions.php', // Partials JS and SCSS import functions
+		'functions/get-posts.php', // Function to get posts by ID (ie to be used in metaboxes functions)
 		'functions/sidebar-toc.php', // TOC sidebar in features, integrations, blogs etc.
 		'functions/taxonomies.php', // Import Custom Taxonomies
 		'functions/post-types.php', // Import Custom Post Types

--- a/functions/get-posts.php
+++ b/functions/get-posts.php
@@ -1,0 +1,48 @@
+<?php
+
+// Gets reviews posts to be used in reviews metaboxes
+
+function get_reviews() {
+		$query_args = array(
+			'post_type' => 'ms_reviews',
+			'posts_per_page' => -1,
+			'fields'         => 'id',
+		);
+
+		$show_posts    = new WP_Query( $query_args );
+
+		while ( $show_posts->have_posts() ) :
+			$show_posts->the_post();
+			$post_lang = apply_filters( 'wpml_post_language_details', null, get_the_id() );
+			if ( 'en' === $post_lang['language_code'] ) {
+				$reviews_posts[ get_the_id() ] = str_replace( '^', '', get_the_title() );
+			}
+		endwhile;
+
+		wp_reset_query();
+
+		return $reviews_posts;
+}
+
+	// Gets Directory posts IDs
+function get_directory_contacts() {
+	$query_args = array(
+		'post_type' => 'ms_directory',
+		'posts_per_page' => -1,
+		'fields'         => 'id',
+	);
+		
+	$show_posts    = new WP_Query( $query_args );
+
+	while ( $show_posts->have_posts() ) :
+		$show_posts->the_post();
+		$post_lang = apply_filters( 'wpml_post_language_details', null, get_the_id() );
+		if ( 'en' === $post_lang['language_code'] ) {
+			$details_posts[ get_the_id() ] = str_replace( '^', '', get_the_title() );
+		}
+		endwhile;
+
+	wp_reset_query();
+
+	return $details_posts;
+}

--- a/lib/metaboxes/reviews.php
+++ b/lib/metaboxes/reviews.php
@@ -4,24 +4,6 @@ add_filter( 'simple_register_taxonomy_settings', 'add_reviews_taxonomy_metaboxes
 
 function add_reviews_taxonomy_metaboxes( $settings ) {
 
-	$query_args = array(
-		'post_type' => 'ms_reviews',
-		'posts_per_page' => -1,
-	);
-
-	$show_posts    = new WP_Query( $query_args );
-
-	while ( $show_posts->have_posts() ) :
-		$show_posts->the_post();
-		$post_lang = apply_filters( 'wpml_post_language_details', null, get_the_id() );
-		if ( 'en' === $post_lang['language_code'] ) {
-			$reviews_posts[ get_the_id() ] = str_replace( '^', '', get_the_title() );
-		}
-	endwhile;
-
-	wp_reset_postdata();
-
-
 	$settings[] = array(
 		'id'       => 'ms_reviews_category',
 		'taxonomy' => array( 'ms_reviews_categories' ),
@@ -58,7 +40,7 @@ function add_reviews_taxonomy_metaboxes( $settings ) {
 				'label'       => 'What is article (bottom)',
 				'type'        => 'select',
 				'placeholder' => 'Select What is Article',
-				'options'     => $reviews_posts,
+				'options'     => get_reviews(),
 			),
 		),
 	);
@@ -264,40 +246,7 @@ function add_reviews_media( $media ) {
 add_filter( 'simple_register_metaboxes', 'add_reviews_details' );
 
 function add_reviews_details( $details ) {
-	$query_args = array(
-		'post_type' => 'ms_directory',
-		'posts_per_page' => -1,
-	);
 	
-	$show_posts    = new WP_Query( $query_args );
-
-	while ( $show_posts->have_posts() ) :
-		$show_posts->the_post();
-		$post_lang = apply_filters( 'wpml_post_language_details', null, get_the_id() );
-		if ( 'en' === $post_lang['language_code'] ) {
-			$details_posts[ get_the_id() ] = str_replace( '^', '', get_the_title() );
-		}
-	endwhile;
-	wp_reset_postdata();
-
-	$howitworks_args = array(
-		'post_type' => 'ms_reviews',
-		'posts_per_page' => -1,
-	);
-
-	$query_posts    = new WP_Query( $howitworks_args );
-
-	while ( $query_posts->have_posts() ) :
-		$query_posts->the_post();
-		$post_lang = apply_filters( 'wpml_post_language_details', null, get_the_id() );
-		if ( 'en' === $post_lang['language_code'] ) {
-			$howitworks_posts[ get_the_id() ] = str_replace( '^', '', get_the_title() );
-		}
-	endwhile;
-
-	wp_reset_postdata();
-
-
 	$details[] = array(
 		'id'        => 'ms_reviews_details',
 		'name'      => 'Details',
@@ -309,14 +258,14 @@ function add_reviews_details( $details ) {
 				'label'       => 'Directory Contacts',
 				'type'        => 'select',
 				'placeholder' => 'Select Directory post',
-				'options'     => $details_posts,
+				'options'     => get_directory_contacts(),
 			),
 			array(
 				'id'          => 'how_it_works',
 				'label'       => 'How it works post below',
 				'type'        => 'select',
 				'placeholder' => 'Select How it works post',
-				'options'     => $howitworks_posts,
+				'options'     => get_reviews(),
 			),
 		),
 	);


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed PHP memory allocation due to queriing posts with all data

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes