### PR TITLE
fix: remove trailing slash for pdf files

### DIFF
--- a/functions/content-filters.php
+++ b/functions/content-filters.php
@@ -264,7 +264,7 @@ add_action( 'wp_head', 'end_wp_head_buffer', PHP_INT_MAX );
 
 function add_trailing_slash( $html ) {
 	$output = preg_replace_callback(
-		'/(href=\")([^"]{3,255}live[^"]{3,255}[^0-9|png|jpg|gif|svg|][^\/])(\")/i',
+		'/(href=\")([^"]{3,255}live[^"]{3,255}[^0-9|png|jpg|gif|svg|pdf|][^\/])(\")/i',
 		function ( $matches ) {
 			return $matches[1] . $matches[2] . '/' . $matches[3];
 		},


### PR DESCRIPTION
**Changes proposed in this Pull Request**
remove trailing slash for pdf files

verify here then https://admin.liveagent.com/gdpr/

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

