### PR TITLE
[969] Removed vertical space for images on mobile in blocks with aside

### DIFF
--- a/assets/styles/components/_Block.scss
+++ b/assets/styles/components/_Block.scss
@@ -479,6 +479,15 @@ scss/at-extend-no-missing-placeholder */
 		margin-top: 0 !important;
 		margin-bottom: $block-space-sm !important;
 
+		&.image-left,
+		&.image-right {
+
+			.elementor-widget-image .elementor-widget-container {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+
 		&.image-right {
 
 			.elementor-container {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed vertical space for images on mobile in blocks with aside

**Testing instructions**
Check vertical space for images on mobile in blocks with aside

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#969
