### PR TITLE
fix: adding theme versioning for icons.svg

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -349,7 +349,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/QualityUnit/wordpress-icons.git",
-                "reference": "5e60cddea6c6f7d6c375f45f392a2ce89892a9de"
+                "reference": "b92d88fe3a7700643e86622eaf7d8c26eb6023d3"
             },
             "default-branch": true,
             "type": "wordpress-icons",
@@ -357,7 +357,7 @@
                 "GPL-2.0-only"
             ],
             "description": "QU WordPress Themes icons",
-            "time": "2022-11-30T13:34:54+00:00"
+            "time": "2022-12-06T13:57:01+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/functions/content-filters.php
+++ b/functions/content-filters.php
@@ -73,7 +73,7 @@ function insert_svg_icons( $content ) {
 		if ( isset ( $class_fragment[2] ) ) {
 			$fragment = $class_fragment[2];
 			$svg = $dom->createDocumentFragment();
-			$svg->appendXML( '<svg class="icon icon-' . $fragment . '"><use xlink:href="' . get_template_directory_uri() . '/assets/images/icons.svg?'. THEME_VERSION . '#' . $fragment . '"></use></svg>' );
+			$svg->appendXML( '<svg class="icon icon-' . $fragment . '"><use xlink:href="' . get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#' . $fragment . '"></use></svg>' );
 			if ( ! str_contains( $class, 'icn-after' ) and $icon !== $svg ) {
 				$icon->insertBefore( $svg, $icon->firstChild );
 			}

--- a/lib/widgets/qu-reviews/reviews.php
+++ b/lib/widgets/qu-reviews/reviews.php
@@ -106,7 +106,7 @@ function qu_reviews_init() {
 								rating( $editor_average, $layout, $meta ) . '
 							<div class="qu-Reviews__post--arrow">
 								<svg class="arrow">
-									<use xlink:href="' . get_template_directory_uri() . '/assets/images/icons.svg#chevron-right"></use>
+									<use xlink:href="' . get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#chevron-right"></use>
 								</svg>
 							</div>
 						</div>' .

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -69,7 +69,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 							<li>
 								<a href="<?php _e( 'https://www.instagram.com/liveagent/', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s Instagram', 'ms' ); ?>">
 									<svg>
-										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-instagram' ) ?>"></use>
+										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-instagram' ) ?>"></use>
 									</svg>
 								</a>
 							</li>
@@ -78,7 +78,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 							<li>
 								<a href="<?php _e( 'https://www.facebook.com/LiveAgent/', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s Facebook', 'ms' ); ?>">
 									<svg>
-										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-facebook' )
+										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-facebook' )
 										?>"></use>
 									</svg>
 								</a>
@@ -88,7 +88,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 							<li>
 								<a href="<?php _e( 'https://twitter.com/LiveAgent', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s Twitter', 'ms' ); ?>">
 									<svg>
-										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-twitter' ) ?>"></use>
+										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-twitter' ) ?>"></use>
 									</svg>
 								</a>
 							</li>
@@ -97,7 +97,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 							<li>
 								<a href="<?php _e( 'https://www.linkedin.com/company/liveagent/', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s LinkedIn', 'ms' ); ?>">
 									<svg>
-										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-linkedin' ) ?>"></use>
+										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-linkedin' ) ?>"></use>
 									</svg>
 								</a>
 							</li>
@@ -106,7 +106,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 							<li>
 								<a href="<?php _e( 'https://www.youtube.com/channel/UCSG5TrYcDozs6jkLf66taBg', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s YouTube', 'ms' ); ?>">
 									<svg>
-										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-youtube' ) ?>"></use>
+										<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-youtube' ) ?>"></use>
 									</svg>
 								</a>
 							</li>
@@ -114,7 +114,7 @@ wp_enqueue_style( 'footer', get_template_directory_uri() . '/assets/dist/layouts
 						<li>
 							<a href="<?php _e( 'https://wa.me/17862041375', 'ms' ); ?>" target="_blank" title="<?php _e( 'LiveAgent\'s WhatsApp', 'ms' ); ?>">
 								<svg>
-									<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg#social-whatsapp' ) ?>"></use>
+									<use xlink:href="<?= esc_url( get_template_directory_uri() . '/assets/images/icons.svg?' . THEME_VERSION . '#social-whatsapp' ) ?>"></use>
 								</svg>
 							</a>
 						</li>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Adding theme versioning for icons.svg fragment calls across the template

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
