### PR TITLE
[1090] fix: subtitle header only if filled in, removed reviews word in header

### DIFF
--- a/templates/content-archive-ms_reviews-sorting.php
+++ b/templates/content-archive-ms_reviews-sorting.php
@@ -57,8 +57,7 @@
 
 	<div class="Category__content__description">
 		<div>
-			<span id="countPosts"><?= esc_html( $query_posts->post_count . ' ' . $subpage->name ); ?></span>&nbsp;
-			<?= esc_html( ' ' . __( 'reviews', 'use-case' ) ); ?>
+			<span id="countPosts"><?= esc_html( $query_posts->post_count . ' ' . $subpage->name ); ?></span>
 		</div>
 	</div>
 </div>

--- a/templates/content-archive-ms_reviews.php
+++ b/templates/content-archive-ms_reviews.php
@@ -55,9 +55,15 @@
 				<h1 class="FullHeadline__title">
 					<?= esc_html( $subpage->name ); ?>
 				</h1>
+				<?php
+				if ( isset( $subpage->description ) ) {
+					?>
 				<h3 class="FullHeadline__subtitle">
 					<?= esc_html( $subpage->description ); ?>
 				</h3>
+					<?php
+				}
+				?>
 				<?php require_once get_template_directory() . '/templates/content-archive-ms_reviews-sorting.php'; ?>
 			</div>
 		</div>
@@ -88,7 +94,7 @@
 		</div>
 
 		<?php
-			$whatis_post_id    = get_term_meta( $subpage->term_id, 'category_whatis_article', true );
+			$whatis_post_id = get_term_meta( $subpage->term_id, 'category_whatis_article', true );
 			
 		if ( isset( $whatis_post_id ) ) {
 			$whatis_post       = get_post( $whatis_post_id )->post_content;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
subtitle header only if filled in, removed reviews word in header

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#1090
