### PR TITLE
[2455] Tooltips in block pricing blocks

### DIFF
--- a/assets/styles/shortcodes/BlockPricing.scss
+++ b/assets/styles/shortcodes/BlockPricing.scss
@@ -78,41 +78,37 @@
 
 	.pricing__tags {
 		$gutter: 1em;
-
 		display: flex;
 		flex-flow: wrap row;
 		justify-content: flex-start;
+		align-items: center;
 		margin: math.div(-$gutter, 2);
 
 		> * {
-			padding: math.div($gutter, 2);
-		}
+			$font-size: 12;
+			display: flex;
+			margin: math.div($gutter, 2);
+			padding: 0 em(13, $font-size);
+			font-size: em($font-size);
+			line-height: em(26, $font-size);
+			font-weight: $font-weight-semi;
+			border-radius: em(13, $font-size);
+			color: #1e1e1e;
+			background-color: #e3f2ff;
 
-		div:first-of-type {
+			> span {
+				display: flex;
+			}
 
-			span {
+			&:first-of-type {
 				background-color: #efe6f8;
 			}
-		}
 
-		div:last-of-type {
+			&:last-of-type {
 
-			span {
-				color: $medium-gray;
-				background-color: $lightest-gray;
+				@include color(color, font-color-medium);
+				background-color: transparent;
 			}
-		}
-
-		&__label {
-			color: $black;
-			background-color: #e3f2ff;
-			padding: 0.5em 1.5em;
-			border-radius: 50px;
-			font-size: 12px;
-			font-weight: $font-weight-semi;
-			line-height: $line-height-default;
-			font-family: $font-secondary;
-			text-align: center;
 		}
 	}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed labels in pricing block for correct display of tooltip icon (after html markup change in elementor).
New elementor markup:
`<div class="pricing__tags">`
`    <div class="pricing__tags__label">7 or 30 days free trial&nbsp;`
`        <div class="Tooltip">`
`            <span class="fontello-info"></span>`
`            <span class="Tooltip__text">Free trial for 7 days with a free email, or 30 days with a company email</span>`
`        </div>`
`    </div>`
`    <div class="pricing__tags__label">No Credit Card required</div>`
`    <div class="pricing__tags__label">and many more</div>`
`</div>`

**Testing instructions**
Check tooltip icons in pricing blocks.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/la-marketing#2455
