### PR TITLE
[1122] Toggle signup form free trial message

### DIFF
--- a/lib/shortcodes/signup-form.php
+++ b/lib/shortcodes/signup-form.php
@@ -101,12 +101,15 @@ function ms_signup_form( $atts ) {
             const mailRegex = '@(gmail.com|outlook.com|yahoo.com|zoho.com|aol.com|icloud.com|yandex' + '.com|gmx.us|@gmx.com)$';
             const mailInput = document.querySelector('input[type="email"]');
             const mailMessage = document.querySelector('[data-id="messageTrial"]');
+            const classMessageToggle = "hidden";
             function checkCompanyMail() {
                 const mailValue = mailInput.value;
                 if (mailValue) {
                     const mailSecondary = new RegExp(mailRegex).test(mailValue);
                     if(mailSecondary) {
-                        mailMessage.classList.remove("hidden");
+                        mailMessage.classList.remove(classMessageToggle);
+                    }else{
+                        mailMessage.classList.add(classMessageToggle);
                     }
                 }
             }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Hide message in signup form when an email address which we don't recognize as free is entered.

**Testing instructions**
Check signup form on trial page.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#1122
