### PR TITLE
[2588] Rearrange the order in which CSS files load to minimise CLS 

### DIFF
--- a/assets/styles/components/SignupSidebar.scss
+++ b/assets/styles/components/SignupSidebar.scss
@@ -46,20 +46,24 @@ no-descending-specificity, value-keyword-case, selector-id-pattern */
 		}
 	}
 
-	input {
+	.Signup__sidebar__item {
 
-		@include color(background-color, main-background);
-		@include color(color, font-color-level3);
-		width: 100%;
-		height: 2.75rem;
-		border: 1px solid $medium-gray-inputs;
-		font-size: 0.8125rem;
-		padding-left: 1em;
+		input {
 
-		@include input-placeholder() {
-			color: currentColor;
+			@include color(background-color, main-background);
+			@include color(color, font-color-level3);
+			width: 100%;
+			height: 2.75rem;
+			border: 1px solid $medium-gray-inputs;
+			font-size: 0.8125rem;
+			padding-left: 1em;
+
+			@include input-placeholder() {
+				color: currentColor;
+			}
 		}
 	}
+
 
 	.ErrorMessage {
 

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -55,6 +55,11 @@ add_action(
 
 		if ( is_page_template( 'template-blog-header.php' ) || is_page_template( 'template-academy-header.php' ) ) {
 			wp_enqueue_style( 'elementor-custom', get_template_directory_uri() . '/assets/dist/common/elementor-custom' . isrtl() . wpenv() . '.css', false, THEME_VERSION );
+
+			if ( is_page_template( 'template-blog-header.php' ) ) {
+				wp_enqueue_style( 'signup-sidebar', get_template_directory_uri() . '/assets/dist/components/SignupSidebar' . isrtl() . wpenv() . '.css', false, THEME_VERSION );
+				wp_enqueue_style( 'post', get_template_directory_uri() . '/assets/dist/pages/post' . isrtl() . wpenv() . '.css', false, THEME_VERSION );
+			}
 		}
 
 		if ( ! is_page_template( 'elementor.php' ) ) {

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -2,13 +2,10 @@
 	/**
 	 * Template Name: Page Like Blog Post – Helpdesk Header
 	 */
-	set_custom_source( 'components/SidebarTOC', 'css' );
-	set_custom_source( 'components/SignupSidebar', 'css' );
-	set_custom_source( 'pages/post', 'css' );
+
 	set_custom_source( 'pages/blog', 'css' );
 	set_custom_source( 'common/splide', 'css' );
 	set_custom_source( 'splide', 'js' );
-	set_custom_source( 'sidebar_toc', 'js' );
 	set_custom_source( 'custom_lightbox', 'js' );
 	global $post;
 	$page_title = str_replace( '^', '', get_the_title() );
@@ -26,7 +23,6 @@
 		);
 	}
 	?>
-
 
 <div class="Post Post--sidebar-right">
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I changed the import of styles from body to head so that the elements have styles immediately and the content does not bounce

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2588
