### PR TITLE
[2624] FAQs added through urlslab are not showing in "Videos" on LA

### DIFF
--- a/templates/content-single-ms_videos.php
+++ b/templates/content-single-ms_videos.php
@@ -73,6 +73,8 @@ if ( $categories && $categories_url ) {
 
 				<?php the_content(); ?>
 
+				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
+
 				<div class="Post__buttons" style="margin-top: 2em;">
 					<a href="<?php _e( '/videos/', 'ms' ); ?>" class="Button Button--outline Button--back"><span><?php _e( 'Back to Videos', 'ms' ); ?></span></a>
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added only urlslab FAQ shortcode to single page of videos

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2624