### PR TITLE
[2629] The pricing deal banner is not fully visible

### DIFF
--- a/assets/styles/components/AnnouncementBar.scss
+++ b/assets/styles/components/AnnouncementBar.scss
@@ -183,14 +183,13 @@ body {
 	}
 
 	.announcement--active {
-		padding-top: calc($Announcement_bar_height_mobile + 5.625em) !important;
 
 		.Header {
-			top: $Announcement_bar_height_mobile;
 			animation: top 0.3s ease;
 		}
 
-		@media (min-width: $breakpoint-mobile ) {
+		@media (min-width: $breakpoint-tablet-landscape ) {
+			padding-top: calc($Announcement_bar_height + 5.625em) !important;
 
 			.Header {
 				top: $Announcement_bar_height;

--- a/assets/styles/components/AnnouncementBar.scss
+++ b/assets/styles/components/AnnouncementBar.scss
@@ -166,7 +166,7 @@ body {
 
 					.Announcement__bar__col__right {
 						width: 50%;
-						margin-top: 0.5em;
+						margin-top: auto;
 						display: block;
 					}
 

--- a/assets/styles/components/AnnouncementBar.scss
+++ b/assets/styles/components/AnnouncementBar.scss
@@ -91,9 +91,9 @@ body {
 
 					img {
 
-						@include square(100%);
-
-						object-fit: cover;
+						width: 100%;
+						height: auto;
+						object-fit: contain;
 						object-position: left;
 						overflow: visible;
 					}
@@ -105,7 +105,11 @@ body {
 				.wrapper {
 
 					.Announcement__bar__col__right {
-						margin-top: 0;
+
+						img {
+							height: 100%;
+							object-fit: cover;
+						}
 					}
 				}
 
@@ -163,15 +167,16 @@ body {
 			.Announcement__bar {
 
 				.wrapper {
+					display: grid;
+					grid-template-columns: repeat(2, 1fr);
 
 					.Announcement__bar__col__right {
-						width: 50%;
-						margin-top: auto;
-						display: block;
+						display: flex;
+						flex-direction: column;
+						justify-content: flex-end;
 					}
 
 					.Announcement__bar__col__left {
-						width: 50%;
 
 						h2 {
 							font-size: 2.125em;

--- a/assets/styles/components/AnnouncementBar.scss
+++ b/assets/styles/components/AnnouncementBar.scss
@@ -102,6 +102,14 @@ body {
 
 			&.ai-assistant {
 
+				.wrapper {
+
+					.Announcement__bar__col__right {
+						margin-top: 0;
+					}
+				}
+
+
 				.Announcement__bar__col__left {
 
 					h2 {
@@ -155,14 +163,15 @@ body {
 			.Announcement__bar {
 
 				.wrapper {
-					display: grid;
-					grid-template-columns: repeat(2, 1fr);
 
 					.Announcement__bar__col__right {
+						width: 50%;
+						margin-top: 0.5em;
 						display: block;
 					}
 
 					.Announcement__bar__col__left {
+						width: 50%;
 
 						h2 {
 							font-size: 2.125em;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I removed paddings on mobile devices and add correct padding to app container if is announcement bar active on the desktop.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2629
