### PR TITLE
[2783] Expert's note element missing backround

### DIFF
--- a/templates/content-single-ms_glossary.php
+++ b/templates/content-single-ms_glossary.php
@@ -47,11 +47,11 @@ $page_header_args = array(
 
 				<?php
 				$shortcode_text = do_shortcode( '[urlslab-generator id="1"]' );
-
+				$background_url = get_template_directory_uri() . '/assets/images/cta_new_bg.svg';
 				if ( ! empty( $shortcode_text ) ) {
 					?>
 
-					<div class="BlockDiscover BlockDiscover--expert">
+					<div class="BlockDiscover BlockDiscover--expert" style="background-image: url('<?= esc_attr( $background_url )?>')">
 						<p class="BlockDiscover__title"><?php _e( 'Expert note', 'ms' ); ?></p>
 						<p class="BlockDiscover__text"><?php echo $shortcode_text; //@codingStandardsIgnoreLine ?></p>
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added bg style to php for block discover expert element on glossary 

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2783
