### PR TITLE
[2742] Fix urls for glossary single and discover shortcode

### DIFF
--- a/lib/shortcodes/discover.php
+++ b/lib/shortcodes/discover.php
@@ -21,7 +21,7 @@ function ms_discover( $atts ) {
 	?>
 
 
-	<div class="BlockDiscover BlockDiscover--<?= esc_attr( $atts['type'] ); ?>" style="background-image: url('<?= esc_attr( $background_url )?>')">
+	<div class="BlockDiscover BlockDiscover--<?= esc_attr( $atts['type'] ); ?>" style="background-image: url(<?= esc_attr( $background_url )?>)">
 		<p class="BlockDiscover__title"><?= esc_html( $atts['title'] ); ?></p>
 		<p class="BlockDiscover__text"><?= esc_html( $atts['text'] ); ?></p>
 

--- a/templates/content-single-ms_glossary.php
+++ b/templates/content-single-ms_glossary.php
@@ -51,7 +51,7 @@ $page_header_args = array(
 				if ( ! empty( $shortcode_text ) ) {
 					?>
 
-					<div class="BlockDiscover BlockDiscover--expert" style="background-image: url('<?= esc_attr( $background_url )?>')">
+					<div class="BlockDiscover BlockDiscover--expert" style="background-image: url(<?= esc_attr( $background_url )?>)">
 						<p class="BlockDiscover__title"><?php _e( 'Expert note', 'ms' ); ?></p>
 						<p class="BlockDiscover__text"><?php echo $shortcode_text; //@codingStandardsIgnoreLine ?></p>
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
i fixed urls for glossary single and discover shortcode. Just remove '' form code

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2742
