### PR TITLE
[2844] Missing background behind input info icon

### DIFF
--- a/assets/styles/components/Signup.scss
+++ b/assets/styles/components/Signup.scss
@@ -429,6 +429,7 @@
 					&::before {
 
 						@include color(color, font-color-normal);
+						background-color: $white;
 					}
 
 					&:hover {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added background color for tooltip icon

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#2844
