### PR TITLE
fix: disallow percentage character in email

### DIFF
--- a/assets/scripts/static/crmForms.js
+++ b/assets/scripts/static/crmForms.js
@@ -136,6 +136,10 @@ class CrmFormHandler {
 							// disallow typing unwanted characters
 							e.target.value = currentValue.replace( regex, '' );
 
+							// additionally disallow defined characters
+							if ( key === 'email' ) {
+								e.target.value = currentValue.replace( /%/g, '' );
+							}
 							// debounced check of user input
 							clearTimeout( this.liveValidationTimeout );
 							this.liveValidationTimeout = setTimeout( () => {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Disallowed usage of `%` in email field.
Name field was already disallowed in name field. 

Close QualityUnit/web-issues#2969
