### PR TITLE
[3003] PHP Warning: foreach() argument must be of type array|object

### DIFF
--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -13,8 +13,9 @@ $page_header_args = array(
 	'toc'   => true,
 	'cta_button' => get_cta_button_data(),
 );
+
 $categories       = get_the_terms( $post->ID, 'category' );
-if ( isset( $categories ) ) {
+if ( is_array( $categories ) ) {
 	$page_header_tags = array();
 	foreach ( $categories as $category ) {
 		$page_header_tags[0]['list'][] = array(


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added condition for categories on the content single template

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3003
