### PR TITLE
[3072] Missing icons in setup interactive element 

### DIFF
--- a/assets/styles/shortcodes/IntroductionVideos.scss
+++ b/assets/styles/shortcodes/IntroductionVideos.scss
@@ -139,7 +139,6 @@
 						.tab-icon {
 							margin-right: 0;
 							background-size: contain;
-							content: "";
 							position: absolute;
 
 							@include square(1.625em);


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I removed `content:""` css from img element because `content:""` is only for pseudoelements as before and after

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3072
