### PR TITLE
[3135] Hide title "Related articles" if empty

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,6 +15,7 @@ $theme_includes = array(
 	'functions/content-filters.php', // Content filters
 	'functions/content-filters-learn-more.php', // Content filters for Block--learnMore
 	'functions/import-functions.php', // Partials JS and SCSS import functions
+	'functions/urlslab-related-posts.php', // Related posts
 	'lib/assets.php',             // Scripts and stylesheets
 	'lib/extras.php',             // Custom functions
 	'lib/setup.php',              // Theme setup

--- a/functions/urlslab-related-posts.php
+++ b/functions/urlslab-related-posts.php
@@ -1,0 +1,17 @@
+<?php
+
+function urlslab_display_related_resources() {
+	// do_shortcode for related resources
+	$related_resources = do_shortcode( '[urlslab-related-resources url="' . get_the_permalink() . '" related-count="4" show-image="true" show-summary="true"]' );
+
+	if ( ! empty( $related_resources ) ) :
+		?>
+		<div class="Post__content__resources">
+			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
+			<div class="SimilarSources">
+				<?= wp_kses_post( $related_resources ); ?>
+			</div>
+		</div>
+	<?php
+	endif;
+}

--- a/functions/urlslab-related-posts.php
+++ b/functions/urlslab-related-posts.php
@@ -12,6 +12,6 @@ function urlslab_display_related_resources() {
 				<?= wp_kses_post( $related_resources ); ?>
 			</div>
 		</div>
-	<?php
+		<?php
 	endif;
 }

--- a/template-academy-header.php
+++ b/template-academy-header.php
@@ -158,13 +158,7 @@
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h3"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/template-academy.php
+++ b/template-academy.php
@@ -66,13 +66,7 @@
 				</div>
 
 				<?php if ( ICL_LANGUAGE_CODE === 'en' ) { ?>
-					<div class="Post__content__resources">
-						<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-						<div class="SimilarSources">
-							<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-						</div>
-					</div>
+					<?php urlslab_display_related_resources(); ?>
 				<?php } ?>
 			</div>
 		</div>

--- a/template-blog-header.php
+++ b/template-blog-header.php
@@ -34,12 +34,7 @@
 			<div class="Content">
 				<?php the_content(); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 

--- a/template-blog.php
+++ b/template-blog.php
@@ -57,12 +57,7 @@
 			<div class="Content" itemprop="articleBody">
 				<?php the_content(); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_academy.php
+++ b/templates/content-single-ms_academy.php
@@ -71,13 +71,7 @@
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_checklists.php
+++ b/templates/content-single-ms_checklists.php
@@ -115,13 +115,7 @@ $page_header_args         = array(
 
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
 
-				<div class="Post__content__resources">
-					<div class="h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_features.php
+++ b/templates/content-single-ms_features.php
@@ -109,13 +109,7 @@ if ( get_post_meta( get_the_ID(), 'mb_features_mb_features_plan', true ) ) {
 
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_glossary.php
+++ b/templates/content-single-ms_glossary.php
@@ -51,13 +51,7 @@ $page_header_args = array(
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_integrations.php
+++ b/templates/content-single-ms_integrations.php
@@ -161,13 +161,7 @@ if ( get_post_meta( get_the_ID(), 'mb_integrations_mb_integrations_plan', true )
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 
 		</div>

--- a/templates/content-single-ms_reviews.php
+++ b/templates/content-single-ms_reviews.php
@@ -270,12 +270,6 @@ function meta( $metabox_id ) {
 				<?php
 		}
 		?>
-		<div class="Post__content__resources">
-			<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-			<div class="SimilarSources">
-				<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-			</div>
-		</div>
+		<?php urlslab_display_related_resources(); ?>
 	</div>
 </div>

--- a/templates/content-single-ms_templates.php
+++ b/templates/content-single-ms_templates.php
@@ -135,13 +135,7 @@
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single-ms_videos.php
+++ b/templates/content-single-ms_videos.php
@@ -85,13 +85,7 @@ if ( $categories && $categories_url ) {
 					</a>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -8,6 +8,7 @@ $page_header_args = array(
 		'src' => get_the_post_thumbnail_url( $post, 'blog_post_thumbnail' ),
 		'alt' => get_the_title(),
 	),
+	'url' => get_the_permalink(),
 	'title' => get_the_title(),
 	'text'  => do_shortcode( '[urlslab-generator id="6"]' ),
 	'date'  => true,
@@ -102,12 +103,7 @@ if ( is_array( $categories ) ) {
 					</div>
 				</div>
 
-				<div class="Post__content__resources">
-					<div class="Post__sidebar__title h4"><?php _e( 'Related Articles', 'ms' ); ?></div>
-					<div class="SimilarSources">
-						<?php echo do_shortcode( '[urlslab-related-resources related-count="4" show-image="true" show-summary="true"]' ); ?>
-					</div>
-				</div>
+				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I created a function to display related articles via a shortcode from urlslab and added a condition to display the title only if the urlslab shortcode displays something and also added a url parameter to the shortcode.  And i replaced old code in the all templates

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3135
