### PR TITLE
[3263] calculator is not working

### DIFF
--- a/lib/shortcodes/web-calc.php
+++ b/lib/shortcodes/web-calc.php
@@ -17,12 +17,6 @@ function ms_web_calc( $atts ) {
 	?>
 	<div data-widget>
 		<link <?= ! is_user_logged_in() ? 'data-' : ''; ?>href="<?= esc_url( get_template_directory_uri() ); ?>/apps/web-calc/build/static/css/main.css?<?= esc_html( $sources_ver ); ?>" rel="stylesheet">
-		<?php if ( is_user_logged_in() ) { ?>
-			<script>
-				window.location.href='#showWebCalcGenerator';
-			</script>
-			<div class="h5" style="color: red; text-align: center">Please preview predefined Web Calc in Privacy mode or log out.<br />When logged in, you are enforced to use WebCalc shortcode generator. This message is visible only to logged in users</div>
-		<?php } ?>
 		<div id="webcalcWrapper">
 			<div id="webcalcroot" dir="ltr" class="webcalc--main"></div>
 		</div>
@@ -37,7 +31,7 @@ function ms_web_calc( $atts ) {
 				<?php } ?>
 			})()
 		</script>
-	
+
 		<script <?= ! is_user_logged_in() ? 'data-' : '' ?>src="<?= esc_url( get_template_directory_uri() ); ?>/apps/web-calc/build/static/js/main.js?<?= esc_html( $sources_ver ) ?>"></script>
 	</div>
 	<?php // @codingStandardsIgnoreEnd ?>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I removed code what adding parameter `#showWebCalcGenerator` to url. A then was visible shortcode generator. It was only for testing i think

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3263
