### PR TITLE
[3291] Id attribute for H tags with ID

### DIFF
--- a/assets/scripts/custom/sidebar_toc.js
+++ b/assets/scripts/custom/sidebar_toc.js
@@ -143,10 +143,17 @@ const handleScroll = () => {
 
 			// Sidebar scroll behavior
 			scrollSidebarsElement.forEach( ( el ) => {
-				if ( el.getBoundingClientRect().top - 217 < window.innerHeight ) {
+				const isVisible = el.getBoundingClientRect().top - 217 < window.innerHeight;
+
+				if ( isVisible ) {
 					sidebarTOC.classList.add( 'scrolled' );
 					if ( signupSidebar ) {
 						signupSidebar.classList.add( 'scrolled' );
+					}
+				} else {
+					sidebarTOC.classList.remove( 'scrolled' );
+					if ( signupSidebar ) {
+						signupSidebar.classList.remove( 'scrolled' );
 					}
 				}
 			} );

--- a/functions/sidebar-toc.php
+++ b/functions/sidebar-toc.php
@@ -1,36 +1,38 @@
 <?php
 
 
-//Add ID to every H2 and H3 element in post/page that has no ID. Generated from sanitized text content of element
+////Add ID to every H2 and H3 element in post/page that has no ID. Generated from sanitized text content of element
 function add_id_to_h2( $html ) {
+	// Adds ID only to <h2> and <h3> headings that already have a non-empty ID
 	$html = preg_replace_callback(
-		'/\<h2( id=".+?")?\>(.+?)\<\/h2\>/',
+		'/<h(2|3)([^>]*)id="([^"]+)"([^>]*)>(.*?)<\/h\1>/',
 		function ( $m ) {
-			return '<h2 id="h-' . preg_replace( '/[%\/\:]/i', '', sanitize_title( $m[2] ) ) . '">' . $m[2] . '</h2>';
+			// If the heading already has a non-empty ID and contains text, return it unchanged
+			return trim( $m[5] ) !== '' ? $m[0] : $m[0];
 		},
 		$html
 	);
 
+	// Adds ID only to <h2> headings without an ID
 	$html = preg_replace_callback(
-		'/\<h2(((?!id).).+?)\>(.+?)\<\/h2\>/',
+		'/<h2(?!.*\sid=").*?>(.*?)<\/h2>/',
 		function ( $m ) {
-			return '<h2 ' . $m[1] . ' id="h-' . preg_replace( '/[%\/]/i', '', sanitize_title( $m[3] ) ) . '">' . $m[3] . '</h2>';
+			// Adds ID only if the heading contains text
+			return trim( $m[1] ) !== ''
+				? '<h2 id="h-' . preg_replace( '/[%\/\:]/i', '', sanitize_title( $m[1] ) ) . '">' . $m[1] . '</h2>'
+				: $m[0];
 		},
 		$html
 	);
 
+	// Adds ID only to <h3> headings without an ID
 	$html = preg_replace_callback(
-		'/\<h3( id=".+?")?\>(.+)\<\/h3\>/',
+		'/<h3(?!.*\sid=").*?>(.*?)<\/h3>/',
 		function ( $m ) {
-			return '<h3 id="h-' . preg_replace( '/[%\/\:]/i', '', sanitize_title( $m[2] ) ) . '">' . $m[2] . '</h3>';
-		},
-		$html
-	);
-
-	$html = preg_replace_callback(
-		'/\<h3(((?!id).).+?)\>(.+?)\<\/h3\>/',
-		function ( $m ) {
-			return '<h3 ' . $m[1] . ' id="h-' . preg_replace( '/[%\/]/i', '', sanitize_title( $m[3] ) ) . '">' . $m[3] . '</h3>';
+			// Adds ID only if the heading contains text
+			return trim( $m[1] ) !== ''
+				? '<h3 id="h-' . preg_replace( '/[%\/\:]/i', '', sanitize_title( $m[1] ) ) . '">' . $m[1] . '</h3>'
+				: $m[0];
 		},
 		$html
 	);


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fix for the add_id_to_h2 function, which now:
- Skips headings that already have an ID
- Does not add an ID to headings without text
	
And added logic to remove 'scrolled' class from sidebarTOC and signupSidebar when scrolling back up and elements move out of view.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3291
