### PR TITLE
fix: countdown in the safari

### DIFF
--- a/assets/scripts/custom/countdown.js
+++ b/assets/scripts/custom/countdown.js
@@ -5,44 +5,51 @@ elCountdown.forEach( ( element ) => {
 	const countDownDate = el.getAttribute( 'data-endtime' );
 
 	if ( countDownDate !== null ) {
-		setInterval( function() {
-			let endTime = new Date( countDownDate );
-			endTime = ( Date.parse( endTime ) / 1000 );
+		// Start an interval that updates the countdown every second
+		const interval = setInterval( function() {
+			// Convert the date to an ISO 8601 compatible format for Safari
+			const endTime = new Date( countDownDate.replace( ' ', 'T' ) ).getTime() / 1000;
 
-			let now = new Date();
-			now = ( Date.parse( now ) / 1000 );
+			// Get the current time in seconds
+			const now = new Date().getTime() / 1000;
 
+			// Calculate the remaining time
 			const timeLeft = endTime - now;
 
+			// Calculate days, hours, minutes, and seconds
 			let days = Math.floor( timeLeft / 86400 );
-			let hours = Math.floor( ( timeLeft - ( days * 86400 ) ) / 3600 );
-			let minutes = Math.floor( ( timeLeft - ( days * 86400 ) - ( hours * 3600 ) ) / 60 );
-			let seconds = Math.floor( ( timeLeft - ( days * 86400 ) - ( hours * 3600 ) - ( minutes * 60 ) ) );
+			let hours = Math.floor( ( timeLeft % 86400 ) / 3600 );
+			let minutes = Math.floor( ( timeLeft % 3600 ) / 60 );
+			let seconds = Math.floor( timeLeft % 60 );
 
-			if ( days < '10' ) {
-				days = '0' + days;
-			}
-			if ( hours < '10' ) {
-				hours = '0' + hours;
-			}
-			if ( minutes < '10' ) {
-				minutes = '0' + minutes;
-			}
-			if ( seconds < '10' ) {
-				seconds = '0' + seconds;
-			}
+			// Add a leading zero to single-digit values
+			days = days < 10 ? '0' + days : days;
+			hours = hours < 10 ? '0' + hours : hours;
+			minutes = minutes < 10 ? '0' + minutes : minutes;
+			seconds = seconds < 10 ? '0' + seconds : seconds;
 
+			// If the countdown has ended, set all values to "00" and stop the interval
 			if ( timeLeft <= 0 ) {
 				days = '00';
 				hours = '00';
 				minutes = '00';
 				seconds = '00';
+				clearInterval( interval );
 			}
 
-			el.querySelector( '[data-days]' ).innerHTML = days;
-			el.querySelector( '[data-hours]' ).innerHTML = hours;
-			el.querySelector( '[data-minutes]' ).innerHTML = minutes;
-			el.querySelector( '[data-seconds]' ).innerHTML = seconds;
-		}, 1000 );
+			// Update the countdown display elements, if they exist
+			if ( el.querySelector( '[data-days]' ) ) {
+				el.querySelector( '[data-days]' ).innerHTML = days;
+			}
+			if ( el.querySelector( '[data-hours]' ) ) {
+				el.querySelector( '[data-hours]' ).innerHTML = hours;
+			}
+			if ( el.querySelector( '[data-minutes]' ) ) {
+				el.querySelector( '[data-minutes]' ).innerHTML = minutes;
+			}
+			if ( el.querySelector( '[data-seconds]' ) ) {
+				el.querySelector( '[data-seconds]' ).innerHTML = seconds;
+			}
+		}, 1000 ); // Repeat every 1000ms (1 second)
 	}
 } );


### PR DESCRIPTION
**Changes proposed in this Pull Request**

1.	Safari compatibility issue: 
Safari could not parse the data-endtime attribute due to non-ISO 8601 date format, resulting in Invalid Date.
2.	Error when target elements were missing:
If countdown elements ([data-days], [data-hours], etc.) were absent, it caused runtime errors.
3.	Unnecessary interval execution:
The timer continued running even after the countdown had ended, wasting resources.
4.	Complex and redundant time calculation logic:
Time calculation involved unnecessary steps, reducing readability and increasing error potential.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
