### PR TITLE
Added support for disabling anchor buttons

### DIFF
--- a/assets/scripts/app/app.js
+++ b/assets/scripts/app/app.js
@@ -198,9 +198,12 @@
 	const form = query( '.Signup__form' );
 
 	function scroll( element ) {
-		const scrollToPos =
-			form.getBoundingClientRect().top + window.pageYOffset;
+		const scrollToPos = form.getBoundingClientRect().top + window.scrollY;
+
 		element.addEventListener( 'click', ( event ) => {
+			if ( element.hasAttribute( 'data-no-anchor' ) ) {
+				return;
+			}
 			event.preventDefault();
 			window.scroll( {
 				top: scrollToPos - 175,
@@ -211,47 +214,21 @@
 
 	/* Scroll Buttons to Signup Form */
 	if ( query( '.Signup__form' ) !== null ) {
-		if ( queryAll( ".Reviews a[href*='trial']" ).length > 0 ) {
-			queryAll( ".Reviews a[href*='trial']" ).forEach( ( element ) => {
-				scroll( element );
-			} );
-		}
-
-		if ( queryAll( ".Reviews a[href*='free-account']" ).length > 0 ) {
-			queryAll( ".Reviews a[href*='free-account']" ).forEach(
-				( element ) => {
+		[
+			".Reviews a[href*='trial']",
+			".Reviews a[href*='free-account']",
+			".Portals a[href*='trial']",
+			".Block a[href*='trial']",
+			".Block a[href*='free-account']",
+			".BlockPricing a[href*='trial']",
+		].forEach( ( selector ) => {
+			const elements = queryAll( selector );
+			if ( elements.length > 0 ) {
+				elements.forEach( ( element ) => {
 					scroll( element );
-				}
-			);
-		}
-
-		if ( queryAll( ".Portals a[href*='trial']" ).length > 0 ) {
-			queryAll( ".Portals a[href*='trial']" ).forEach( ( element ) => {
-				scroll( element );
-			} );
-		}
-
-		if ( queryAll( ".Block a[href*='trial']" ).length > 0 ) {
-			queryAll( ".Block a[href*='trial']" ).forEach( ( element ) => {
-				scroll( element );
-			} );
-		}
-
-		if ( queryAll( ".Block a[href*='free-account']" ).length > 0 ) {
-			queryAll( ".Block a[href*='free-account']" ).forEach(
-				( element ) => {
-					scroll( element );
-				}
-			);
-		}
-
-		if ( queryAll( ".BlockPricing a[href*='trial']" ).length > 0 ) {
-			queryAll( ".BlockPricing a[href*='trial']" ).forEach(
-				( element ) => {
-					scroll( element );
-				}
-			);
-		}
+				} );
+			}
+		} );
 	}
 
 	/* Login */


### PR DESCRIPTION
**Changes proposed in this Pull Request**
We had JS code that worked so that if there was a trial form in the content, then in all buttons that were for creating a trial account, it would cancel the default linking and rewrite it to an anchor link to the form on that page. So I added support for disabling this function if we want a classic button.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
