### PR TITLE
[3347] - fix: show demo button instead of free trial on header

### DIFF
--- a/assets/styles/layouts/Header.scss
+++ b/assets/styles/layouts/Header.scss
@@ -388,7 +388,8 @@ body {
 						}
 					}
 
-					&--full {
+					&--full,
+					&--outline {
 						margin: 0.5em 1.25em;
 						width: calc(100% - 2.5em);
 					}

--- a/assets/styles/layouts/Header.scss
+++ b/assets/styles/layouts/Header.scss
@@ -409,9 +409,8 @@ body {
 					margin: 0;
 				}
 
-				&.Button--outline {
+				&.Button--full {
 					display: flex;
-					width: 6.25em;
 				}
 
 				span {

--- a/templates/header.php
+++ b/templates/header.php
@@ -99,7 +99,7 @@
 					?>
 				</div>
 				<div class="Header__navigation__buttons__mobile">
-					<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--full">
+					<a href="<?php _e( '/trial/', 'ms' ); ?>" class="Button Button--outline">
 						<span><?php _e( 'Free Trial', 'ms' ); ?></span>
 					</a>
 					<a href="<?php _e( '/login/', 'ms' ); ?>" class="Button Button--login">


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Show demo button instead of free trial demo on header top
section on mobile devices

**Testing instructions**
- Go to any page with header and check on mobile device need visible
demo button on header top section

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3347
