### PR TITLE
[3703] - fix: changed "contact us" multi-widget to chatbot button

### DIFF
--- a/base-scripts.php
+++ b/base-scripts.php
@@ -267,11 +267,14 @@
 <?php
 if (
 		! is_page( array( 'pricing', 'request-demo', 'demo', 'trial', 'thank-you', 'redeem-code', 'free-account', 'tom', 'typing-test', 'tipptest', 'prueba-de-tipeo', 'test-de-saisie', 'test-di-digitazione', 'teste-de-digitacao', 'typetest', 'gepelesi-teszt', 'test-pisania', 'test-na-umenie-nabirat-tekst', 'dazi-ceshi' ) )
-		&& ! is_post_type_archive( array( 'ms_glossary', 'ms_templates', 'ms_academy', 'ms_directory' ) )
+		&& ! is_post_type_archive( array( 'ms_glossary', 'ms_templates', 'ms_academy', 'ms_directory', 'ms_checklists', 'ms_reviews', 'ms_awards' ) )
 		&& ! is_single( array( 'facebook', 'liveagent-huawei', 'twitter', 'viber', 'instagram' ) )
-		&& ! is_singular( array( 'ms_glossary', 'ms_templates', 'ms_academy', 'ms_directory', 'ms_about', 'post' ) )
+		&& ! is_singular( array( 'ms_glossary', 'ms_templates', 'ms_academy', 'ms_directory', 'ms_about', 'ms_checklists', 'ms_reviews', 'ms_awards', 'post' ) )
 		&& ! is_category( array( 'blog', 'news', 'reviews', 'growth', 'support', 'live-chat', 'help-desk-software' ) )
 		&& ! is_search()
+		&& ! check_parent_child_slug( array( 'business', 'industry' ) )
+		&& ! is_tax( 'ms_reviews_categories' )
+
 	) {
 	include_once get_template_directory() . '/contactus-box.php';
 } elseif ( is_page( 'pricing' ) ) {

--- a/functions.php
+++ b/functions.php
@@ -48,6 +48,7 @@ $theme_includes = array(
 	'functions/create-language-menu.php', // Function for generate languages
 	'functions/dynamic-award-badges.php', // Function to place award badges dynamically
 	'functions/get-archive-items-images.php', // Get backgrounds for item on  the archive pages
+	'functions/check-parent-child-slug.php', // Checking pages and subpages for compliance with the slug
 
 );
 

--- a/functions/check-parent-child-slug.php
+++ b/functions/check-parent-child-slug.php
@@ -1,0 +1,15 @@
+<?php
+
+function check_parent_child_slug( array $parent_slugs ): bool {
+
+	global $post;
+
+	$slug = $post->post_name;
+	$parent_id = $post->post_parent;
+
+	if ( $parent_id && in_array( get_post_field( 'post_name', $parent_id ), $parent_slugs, true ) ) {
+		return true;
+	}
+
+	return in_array( $slug, $parent_slugs, true );
+}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed "contact us" multi-widget to chatbot button for
next pages/subpages:
https://www.liveagent.com/business/
https://www.liveagent.com/industry/
https://www.liveagent.com/checklists/
https://www.liveagent.com/reviews/
https://www.liveagent.com/awards/

**Testing instructions**
- Go to above pages and check chatbot button instead contact us" multi-widget

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/la-marketing#3703
