### PR TITLE
[3355] - fix: changed styles that override box-shadow

### DIFF
--- a/apps/web-calc/src/assets/style/common/_variables.scss
+++ b/apps/web-calc/src/assets/style/common/_variables.scss
@@ -150,7 +150,7 @@ $vars: (
 	footer-column-border-color: $light-gray,
 	footer-middle-background-color-1: $dark-orange,
 	footer-middle-background-color-2: $light-orange,
-	box-shadow: 3px 6px 6px 0 rgba($black-real, 0.06),
+	box-shadow-small-soft: 3px 6px 6px 0 rgba($black-real, 0.06),
 	background: linear-gradient(90deg, $light-orange 0%, $dark-orange 100%),
 	background-invert: linear-gradient(90deg, $dark-orange 0%, $light-orange 100%),
 );

--- a/apps/web-calc/src/assets/style/elements/_Block.scss
+++ b/apps/web-calc/src/assets/style/elements/_Block.scss
@@ -1,7 +1,7 @@
 .webcalcBlock {
 
 	@include color(background-color, main-background);
-	@include color(box-shadow, box-shadow);
+	@include color(box-shadow, box-shadow-small-soft);
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/apps/web-calc/src/assets/style/elements/_Feature.scss
+++ b/apps/web-calc/src/assets/style/elements/_Feature.scss
@@ -1,6 +1,6 @@
 .Feature {
 
-	@include color(box-shadow, box-shadow);
+	@include color(box-shadow, box-shadow-small-soft);
 	position: relative;
 	display: inline-flex;
 	align-items: center;

--- a/apps/web-calc/src/assets/style/elements/_Select.scss
+++ b/apps/web-calc/src/assets/style/elements/_Select.scss
@@ -10,7 +10,7 @@
 	&__control {
 
 		@include color(background-color, main-background);
-		@include color(box-shadow, box-shadow);
+		@include color(box-shadow, box-shadow-small-soft);
 		display: flex;
 		align-items: center;
 		font-size: 0.875rem;
@@ -23,7 +23,8 @@
 		&--menu-is-open {
 
 			&::after {
-				box-shadow: 3px 6px 6px 0 rgba(0, 0, 0, 0.06);
+
+				@include color(box-shadow, box-shadow-small-soft);
 				position: absolute;
 				bottom: 0;
 				left: 0;
@@ -109,7 +110,7 @@
 		&-list {
 
 			@include color(background-color, main-background);
-			@include color(box-shadow, box-shadow);
+			@include color(box-shadow, box-shadow-small-soft);
 			@include scrollbar;
 			display: block;
 			position: absolute;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed styles that override box-shadow

**Testing instructions**
- Go to page with web-calc widget e.g. /zendesk-alternative/ and
check that "Start Free Trial" form has correct-box-shadow

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3355
