### PR TITLE
[3358] - huge font size h2 on mobile

### DIFF
--- a/assets/styles/common/_elementor.scss
+++ b/assets/styles/common/_elementor.scss
@@ -68,8 +68,11 @@
 	&.large-heading {
 
 		h2 {
-			font-size: $font-size-h2-xxl !important;
-			line-height: $line-height-h2-xxl !important;
+
+			@media (min-width: ($breakpoint-desktop)) {
+				font-size: $font-size-h2-xxl !important;
+				line-height: $line-height-h2-xxl !important;
+			}
 		}
 	}
 

--- a/assets/styles/components/_HeroHeadlineBanner.scss
+++ b/assets/styles/components/_HeroHeadlineBanner.scss
@@ -64,11 +64,35 @@
 
 			&__cta {
 
+				.Buttons {
+					display: flex;
+					flex-wrap: wrap;
+					gap: 1em;
+					row-gap: 0.5em;
+
+					@media (max-width: $breakpoint-tablet) {
+						justify-content: center;
+						margin-bottom: 0.5em;
+					}
+				}
+
 				.Button {
 					width: auto;
+
+					+ .Button {
+						margin: 0;
+					}
 				}
 
 				.info__under__button {
+
+					@media (max-width: $breakpoint-tablet) {
+						text-align: center;
+
+						span {
+							margin-right: 0;
+						}
+					}
 
 					span {
 						color: $medium-gray-quotes;

--- a/assets/styles/components/_HeroHeadlineBanner.scss
+++ b/assets/styles/components/_HeroHeadlineBanner.scss
@@ -64,6 +64,10 @@
 
 			&__cta {
 
+				@media (max-width: $breakpoint-tablet) {
+					text-align: center;
+				}
+
 				.Buttons {
 					display: flex;
 					flex-wrap: wrap;

--- a/assets/styles/components/_HorizontalTabs.scss
+++ b/assets/styles/components/_HorizontalTabs.scss
@@ -105,8 +105,11 @@
 		&.large-heading {
 
 			h2 {
-				font-size: $font-size-h2-xxl;
-				line-height: $line-height-h2-xxl !important;
+
+				@media (min-width: ($breakpoint-desktop)) {
+					font-size: $font-size-h2-xxl;
+					line-height: $line-height-h2-xxl !important;
+				}
 			}
 		}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed h2 (large-heading) and few styles on tablet and mobile devices

**Testing instructions**
- Go to front-page and check visual view h2 (large-heading) on mobile and
check hero section on tablet and mobile (buttons need to be with gap and
without margin-left and aligned by center on mobile.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3358
