### PR TITLE
[3376] - fix: removed captera and g2 badges on trial page

### DIFF
--- a/assets/styles/pages/TrialRedesign.scss
+++ b/assets/styles/pages/TrialRedesign.scss
@@ -310,31 +310,6 @@
 			}
 		}
 
-		&__logos {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			margin: 3em -0.8em 0 -0.8em;
-		}
-
-		&__logo a {
-			display: block;
-			padding: 0.8em;
-
-			img {
-				max-width: 100%;
-				max-height: 3.5em;
-			}
-		}
-
-		@media (min-width: $breakpoint-mobile) {
-
-			&__logos {
-				flex-direction: initial;
-				justify-content: space-evenly;
-			}
-		}
-
 		@media (min-width: $breakpoint-tablet-landscape) {
 			width: calc(100% - #{$width-left-sm});
 

--- a/template-redeem-code.php
+++ b/template-redeem-code.php
@@ -36,21 +36,6 @@ set_source( 'redeem-code', 'pages/TrialRedesign', 'css' );
 				</div>
 
 				<?= do_shortcode( '[signupform-redeemcode]' ); ?>
-
-				<div class="Trial__main__logos">
-					<div class="Trial__main__logo">
-						<a href="<?php _e( '/awards/', 'ms' ); ?>">
-							<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/rating_capterra.svg" alt="<?php _e( 'Capterra', 'ms' ); ?>" class="urlslab-skip-lazy">
-						</a>
-					</div>
-
-					<div class="Trial__main__logo">
-						<a href="<?php _e( '/awards/', 'ms' ); ?>">
-							<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/rating_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>" class="urlslab-skip-lazy">
-						</a>
-					</div>
-
-				</div>
 			</div>
 		</div>
 	</div>

--- a/template-trial-redesign.php
+++ b/template-trial-redesign.php
@@ -44,20 +44,6 @@
 				</div>
 
 				<?= do_shortcode( '[signupform]' ); ?>
-
-				<div class="Trial__main__logos">
-					<div class="Trial__main__logo">
-						<a href="<?php _e( '/awards/', 'ms' ); ?>">
-							<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/rating_capterra.svg" alt="<?php _e( 'Capterra', 'ms' ); ?>" class="urlslab-skip-lazy">
-						</a>
-					</div>
-
-					<div class="Trial__main__logo">
-						<a href="<?php _e( '/awards/', 'ms' ); ?>">
-							<img src="<?= esc_url( get_template_directory_uri() ); ?>/assets/images/rating_g2.svg" alt="<?php _e( 'G2 Crowd', 'ms' ); ?>" class="urlslab-skip-lazy">
-						</a>
-					</div>
-				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed captera and g2 badges on trial page

**Testing instructions**
- Go to trial page and check (captera and G2 don't need to be on page)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3376
