### PR TITLE
fix: delete empty space in link

### DIFF
--- a/landing-ppc.php
+++ b/landing-ppc.php
@@ -62,15 +62,9 @@ set_custom_source( 'layouts/LandingPPC', 'css' );
 	  <li>✓ Cancel any time</li>
 	  </ul>
 	  <div class="heroBanner__content__footer__cta">
-	  <a href="<?= get_post_meta( get_the_ID(), 'header_button_url', true );  // @codingStandardsIgnoreLine
-		?>
-		" class="Button Button--full"
-	  title="Considering LiveAgent help desk software? Fill in your details and you can start your Free Trial, no strings attached, no credit card info needed."
-	  hreflang="en-US" onover-preload="1">
-	  <span><?= get_post_meta( get_the_ID(), 'header_button_text', true );  // @codingStandardsIgnoreLine
-		?>
-		</span>
-	  </a>
+			<a href="<?= get_post_meta( get_the_ID(), 'header_button_url', true ); // @codingStandardsIgnoreLine ?>" class="Button Button--full" title="Considering LiveAgent help desk software? Fill in your details and you can start your Free Trial, no strings attached, no credit card info needed." hreflang="en-US" onover-preload="1">
+				<span><?= get_post_meta( get_the_ID(), 'header_button_text', true );  // @codingStandardsIgnoreLine  ?></span>
+			</a>
 	  </div>
 	</div>
 	</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
i delete empty space in `href` attribut because some space in code add to link `href="/trial/%09%09"`

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/la-marketing#3709
