### PR TITLE
[3388] - overlaping elements industry page

### DIFF
--- a/assets/styles/components/HeroHeadlineHome.scss
+++ b/assets/styles/components/HeroHeadlineHome.scss
@@ -624,9 +624,13 @@ value-keyword-case */
 				left: -30%;
 			}
 
-			@media (min-width: $breakpoint-desktop) {
+			@media (min-width: $breakpoint-tablet-landscape) {
 				display: block;
 				font-size: 0.875em;
+			}
+
+			@media (min-width: $breakpoint-desktop-box) {
+				font-size: 1em;
 			}
 
 			@media (min-width: $breakpoint-desktop-big) {

--- a/assets/styles/components/HeroHeadlineHome.scss
+++ b/assets/styles/components/HeroHeadlineHome.scss
@@ -544,7 +544,7 @@ value-keyword-case */
 		.white--bubble {
 			display: none;
 			position: relative;
-			left: -38%;
+			left: -20%;
 			z-index: 2;
 			width: auto;
 			max-width: 29.625em;
@@ -620,8 +620,17 @@ value-keyword-case */
 				font-size: 0.875em;
 			}
 
-			@media (min-width: $breakpoint-desktop-box) {
-				font-size: 1em;
+			@media (min-width: $breakpoint-tablet-landscape) and (max-width: $breakpoint-desktop) {
+				left: -30%;
+			}
+
+			@media (min-width: $breakpoint-desktop) {
+				display: block;
+				font-size: 0.875em;
+			}
+
+			@media (min-width: $breakpoint-desktop-big) {
+				left: -32%;
 			}
 
 			&:not(:nth-of-type(2)) {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added gap between labels and title and text of hero section

**Testing instructions**
- Go to /industry/ page and check hero section, should be
gap between labels and left content

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3388
