### PR TITLE
[3827] The internal links duplicity removal on LPs for PPC campaigns 

### DIFF
--- a/landing-ppc.php
+++ b/landing-ppc.php
@@ -21,7 +21,14 @@ set_custom_source( 'layouts/LandingPPC', 'css' );
   }
 </style>
 
-<div class="LandingPPC urlslab-skip-keywords">
+
+<?php
+// Check if internal linking should be disabled
+$disable_internal_linking = get_post_meta( get_the_ID(), 'enable_internal_linking', true ) !== 'yes';
+$internal_linking_class = $disable_internal_linking ? 'urlslab-skip-keywords' : '';
+?>
+
+<div class="LandingPPC <?php echo esc_attr( $internal_linking_class ); ?>">
   <section class="heroBanner heroBanner--home">
 	<div class="elementor-container elementor-column-gap-default">
 	<div

--- a/landing-ppc.php
+++ b/landing-ppc.php
@@ -21,7 +21,7 @@ set_custom_source( 'layouts/LandingPPC', 'css' );
   }
 </style>
 
-<div class="LandingPPC">
+<div class="LandingPPC urlslab-skip-keywords">
   <section class="heroBanner heroBanner--home">
 	<div class="elementor-container elementor-column-gap-default">
 	<div

--- a/lib/metaboxes/landing-ppc.php
+++ b/lib/metaboxes/landing-ppc.php
@@ -39,6 +39,16 @@ function landing_ppc_metaboxes( $sidebars ) {
 		'post_type' => array( 'ms_landing' ),
 		'fields'    => array(
 			array(
+				'id'          => 'enable_internal_linking',
+				'label'       => 'Internal Linking',
+				'type'        => 'radio',
+				'options'     => array(
+						'yes' => '<span style="color:green; font-weight:bold">Enable</span> - Allow automatic keyword linking',
+						'no'  => '<span style="color:red; font-weight:bold">Disable</span> - No automatic links will be added',
+				),
+				'default'     => 'no',
+		),
+			array(
 				'id'           => 'title',
 				'label'        => 'Main title',
 				'description'  => '',

--- a/lib/metaboxes/landing-ppc.php
+++ b/lib/metaboxes/landing-ppc.php
@@ -43,11 +43,11 @@ function landing_ppc_metaboxes( $sidebars ) {
 				'label'       => 'Internal Linking',
 				'type'        => 'radio',
 				'options'     => array(
-						'yes' => '<span style="color:green; font-weight:bold">Enable</span> - Allow automatic keyword linking',
-						'no'  => '<span style="color:red; font-weight:bold">Disable</span> - No automatic links will be added',
+					'yes' => '<span style="color:green; font-weight:bold">Enable</span> - Allow automatic keyword linking',
+					'no'  => '<span style="color:red; font-weight:bold">Disable</span> - No automatic links will be added',
 				),
 				'default'     => 'no',
-		),
+			),
 			array(
 				'id'           => 'title',
 				'label'        => 'Main title',


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added metabox for disabling internal linking from urlslab. 

**Testing instructions**
Open any landing page, check new metabox "Internal Linking". 
if you chose disable linking then in code added class for disabling `urlslab-skip-keywords`

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/marketing#3827
