### PR TITLE
[3407] Correct banners script URL to point to images directory

### DIFF
--- a/lib/widgets/qu-banners/banners.php
+++ b/lib/widgets/qu-banners/banners.php
@@ -20,7 +20,7 @@ function banners_block_init() {
 		$path_uri = get_template_directory_uri() . '/lib/widgets/qu-banners/';
 		$version  = THEME_VERSION;
 		$js_data  = array(
-			'url' => $path_uri . 'quBannersConfig',
+			'url' => $path_uri . 'images',
 		);
 
 		wp_enqueue_script(

--- a/lib/widgets/qu-banners/banners.php
+++ b/lib/widgets/qu-banners/banners.php
@@ -20,7 +20,7 @@ function banners_block_init() {
 		$path_uri = get_template_directory_uri() . '/lib/widgets/qu-banners/';
 		$version  = THEME_VERSION;
 		$js_data  = array(
-			'url' => $path_uri . 'images',
+			'url' => $path_uri . 'quBannersConfig',
 		);
 
 		wp_enqueue_script(
@@ -33,7 +33,7 @@ function banners_block_init() {
 
 		wp_add_inline_script(
 			'qu_banners_block_editor_script',
-			'const images = ' . wp_json_encode( $js_data ),
+			'window.quBannersConfig = ' . wp_json_encode( $js_data ) . ';',
 			'before'
 		);
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Replaced global `const images` declaration with `window.quBannersConfig` to avoid conflicts with other scripts that may also use the same variable name. This fixes a SyntaxError caused by redeclaring a global const in the editor.

**Testing instructions**
Go to any page, then go to edit page and open console. Shouldn't be there any console error as this :

```
Uncaught SyntaxError: redeclaration of const images
    <anonymous> https://admin.liveagent.com/wp/wp-admin/post.php?post=711384&action=edit&lang=en:3027
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3407