### PR TITLE
feat: disable speculative loading via wordpress filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -49,6 +49,7 @@ $theme_includes = array(
 	'functions/dynamic-award-badges.php', // Function to place award badges dynamically
 	'functions/get-archive-items-images.php', // Get backgrounds for item on  the archive pages
 	'functions/check-parent-child-slug.php', // Checking pages and subpages for compliance with the slug
+	'functions/disable-speculative-loading.php', // Disable speculative loading
 
 );
 

--- a/functions/disable-speculative-loading.php
+++ b/functions/disable-speculative-loading.php
@@ -1,0 +1,3 @@
+<?php
+// Disable Speculative Loading via the Speculation Rules API (since WordPress v6.8).
+add_filter( 'wp_speculation_rules_configuration', '__return_null' );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added a new function to disable speculative loading using the `wp_speculation_rules_configuration` filter. This prevents the Speculation Rules API from preloading resources, improving control over resource loading behavior.

**Testing instructions**
Go to the LA homepage. Open dev tools and in elements find speculative script. You can't find him.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
