### PR TITLE
[3809] - fix: changed aligned on success stories

### DIFF
--- a/assets/styles/elements/_PostTypography.scss
+++ b/assets/styles/elements/_PostTypography.scss
@@ -313,6 +313,14 @@
 					background-image: url(/app/themes/liveagent/assets/images/icon-post-check.svg);
 				}
 			}
+
+			@media (min-width: $breakpoint-tablet-landscape) {
+
+				figure.wp-block-image.size-large {
+					margin-left: -2.8125em;
+					margin-right: -2.8125em;
+				}
+			}
 		}
 
 		&__resources {
@@ -351,7 +359,7 @@
 			overflow: hidden;
 
 			@media (min-width: $breakpoint-tablet-landscape) {
-				margin: 1.875em -3.125em;
+				margin: 1.875em -2.8125em;
 			}
 
 			li {
@@ -399,6 +407,8 @@
 					gap: 0;
 
 					.title {
+						padding-right: 0.445em;
+						padding-left: 0.445em;
 						text-align: center;
 						background: $primary-gradient-reverse;
 						-webkit-background-clip: text;
@@ -408,6 +418,8 @@
 					}
 
 					.text {
+						padding-right: 2.5em;
+						padding-left: 2.5em;
 						text-align: center;
 						font-weight: $font-weight-bold;
 					}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed aligned on success stories wider sections and reduced margins for it

**Testing instructions**
- Go to /use-case-scenarios/matchaflix/ and check aligned text in updated containers

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/marketing#3809
