### PR TITLE
fix: change image object-fit to contain in success__stories shortcode

### DIFF
--- a/assets/styles/shortcodes/SuccessStories.scss
+++ b/assets/styles/shortcodes/SuccessStories.scss
@@ -49,7 +49,7 @@
 			img {
 
 				@include square(100%);
-				object-fit: cover;
+				object-fit: contain;
 				border-radius: $border-radius-16 $border-radius-16 0 0;
 			}
 		}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed image object-fit to contain in success__stories shortcode, added image for nessesary post

**Testing instructions**
- Go to home page to success story section and check images

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes