### PR TITLE
fix: handle async trial installation, no progress needed

### DIFF
--- a/assets/scripts/static/crmForms.js
+++ b/assets/scripts/static/crmForms.js
@@ -389,6 +389,7 @@ class CrmFormHandler {
 					account_id: result.account_id,
 					subdomain: requestData.subdomain,
 					language: requestData.language,
+					async: result.async,
 					...( this.planType !== undefined && { plan_type: this.planType } ),
 					...( isRedeem && { is_redeem: true } ),
 				};

--- a/assets/scripts/static/crmInstaller.js
+++ b/assets/scripts/static/crmInstaller.js
@@ -31,14 +31,7 @@ class CrmInstaller {
 	}
 
 	init = () => {
-		try {
-			const signupResponse = getCookie( 'trial_signup_response' );
-			this.signupData = JSON.parse( decodeURIComponent( signupResponse ) );
-		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			console.error( error );
-		}
-
+		this.readSignUpCookie();
 		if ( ! this.signupData ) {
 			window.location.href = quCrmData.trialUrl;
 			return;
@@ -53,6 +46,11 @@ class CrmInstaller {
 		this.fields.introductionVideos = this.fields.main.querySelector( '.Introduction__videos' );
 		this.fields.progressDoneOverlay = this.fields.main.querySelector( '.progress__done__overlay' );
 		this.fields.redirectButtonPanel = this.fields.main.querySelector( '[data-id="redirectButtonPanel"]' );
+
+		if ( this.signupData.async === true ) {
+			this.handleAsyncInstallation();
+			return;
+		}
 
 		this.showHiddenParts();
 		this.handleInstallation();
@@ -97,9 +95,7 @@ class CrmInstaller {
 				this.setProgress( 100 );
 				this.handleFinishActions();
 				this.handleFinishOverlay();
-
-				// remove cookie after installation, installation process is available even the user refresh page or come back
-				setCookie( 'trial_signup_response', '', -1 );
+				this.removeSignUpCookie();
 
 				if ( data.login_url ) {
 					this.createGoToAppForm( data );
@@ -114,6 +110,12 @@ class CrmInstaller {
 		if ( ! response.success ) {
 			this.setProgressText( response.message );
 		}
+	};
+
+	handleAsyncInstallation = () => {
+		this.setProgressText( this.localized.textProgressAsyncInstallation );
+		this.handleFinishActions();
+		this.removeSignUpCookie();
 	};
 
 	checkInstallationProgress = async () => {
@@ -384,6 +386,23 @@ class CrmInstaller {
 	showHiddenParts = () => {
 		// by default, some parts like percentage and progress indicator are invisible in case the installation is processed for user with corrupted javascript
 		this.fields.progressHeader.querySelectorAll( '.invisible' ).forEach( ( elm ) => elm.classList.remove( 'invisible' ) );
+	};
+
+	readSignUpCookie = () => {
+		try {
+			const cookieData = getCookie( 'trial_signup_response' );
+			if ( cookieData ) {
+				this.signupData = JSON.parse( decodeURIComponent( cookieData ) );
+			}
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( error );
+		}
+	};
+
+	removeSignUpCookie = () => {
+		// remove cookie after installation, installation process is available even the user refresh page or come back
+		setCookie( 'trial_signup_response', '', -1 );
 	};
 
 	handlePapAction = () => {

--- a/lib/trial-signup/class-trial-signup.php
+++ b/lib/trial-signup/class-trial-signup.php
@@ -176,31 +176,32 @@ class Trial_Signup {
 		);
 
 		self::$localized_text = array(
-			'invalid'                   => array(
+			'invalid'                       => array(
 				'name'    => __( 'Field invalid', 'qu_signup' ),
 				'email'   => __( 'Email invalid', 'qu_signup' ),
 				'domain'  => __( 'Domain can not contain http, www or capital letters (A-Z)', 'qu_signup' ),
 				'code'    => __( 'Invalid code.', 'qu_signup' ),
 				'region'  => __( 'Select datacenter region.', 'qu_signup' ),
 				'captcha' => __( 'Verify captcha.', 'qu_signup' ),
-			),
-			'textEmpty'                 => __( "Field can't be empty", 'qu_signup' ),
-			'textTooShort'              => __( 'The input must be at least 3 characters long.', 'qu_signup' ),
-			'textFailedDomain'          => __( 'Failed to validate domain', 'qu_signup' ),
-			'textValidating'            => __( 'Validating...', 'qu_signup' ),
-			'textFailedRetrieve'        => __( 'Failed to retrieve valid progress info.', 'qu_signup' ),
-			'textGoToApp'               => __( 'Go to your App', 'qu_signup' ),
-			'textGoToLiveAgent'         => __( 'Go to LiveAgent', 'qu_signup' ),
-			'textLogInEmail'            => __( 'Log in via email', 'qu_signup' ),
-			'textProgressInstalling'    => __( 'Building Your LiveAgent', 'qu_signup' ),
-			'textProgressLaunching'     => __( 'Halfway there', 'qu_signup' ),
-			'textProgressRedirecting'   => __( 'Almost done, just a moment', 'qu_signup' ),
-			'textProgressFinalizing'    => __( 'Your LiveAgent is ready to use', 'qu_signup' ),
-			'textProgressLoginViaEmail' => __( 'To log in, use the link we sent to your email', 'qu_signup' ),
-			'textError'                 => __( 'Something went wrong.', 'qu_signup' ),
-			'textErrorCaptcha'          => __( 'Cannot load captcha', 'qu_signup' ),
+			), 
+			'textEmpty'                     => __( "Field can't be empty", 'qu_signup' ),
+			'textTooShort'                  => __( 'The input must be at least 3 characters long.', 'qu_signup' ),
+			'textFailedDomain'              => __( 'Failed to validate domain', 'qu_signup' ),
+			'textValidating'                => __( 'Validating...', 'qu_signup' ),
+			'textFailedRetrieve'            => __( 'Failed to retrieve valid progress info.', 'qu_signup' ),
+			'textGoToApp'                   => __( 'Go to your App', 'qu_signup' ),
+			'textGoToLiveAgent'             => __( 'Go to LiveAgent', 'qu_signup' ),
+			'textLogInEmail'                => __( 'Log in via email', 'qu_signup' ),
+			'textProgressInstalling'        => __( 'Building Your LiveAgent', 'qu_signup' ),
+			'textProgressLaunching'         => __( 'Halfway there', 'qu_signup' ),
+			'textProgressRedirecting'       => __( 'Almost done, just a moment', 'qu_signup' ),
+			'textProgressFinalizing'        => __( 'Your LiveAgent is ready to use', 'qu_signup' ),
+			'textProgressLoginViaEmail'     => __( 'To log in, use the link we sent to your email', 'qu_signup' ),
+			'textProgressAsyncInstallation' => __( "Setup is in progress, you'll get an email after completion.", 'qu_signup' ),
+			'textError'                     => __( 'Something went wrong.', 'qu_signup' ),
+			'textErrorCaptcha'              => __( 'Cannot load captcha', 'qu_signup' ),
 		);
-
+		
 		if ( has_filter( 'wpml_current_language' ) ) {
 			$current_lang = apply_filters( 'wpml_current_language', null );
 			if ( $current_lang ) {  


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Handle async trial installation, no progress needed.

**Testing instructions**
When CRM api respond with `async=true` on trial form submission, installation page do not show installation progress. Only notify user with text `Setup is in progress, you'll get an email after completion`


**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] My commits follow the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3577
