### PR TITLE
fix: changed text for trial page

### DIFF
--- a/lib/shortcodes/request-for-proposal-form.php
+++ b/lib/shortcodes/request-for-proposal-form.php
@@ -13,7 +13,7 @@ function ms_request_for_proposal_form( $atts ) {
 			'email_in_description' => __( 'andy@liveagent.com.', 'ms' ),
 			'label1'               => __( 'Customer service since 2004', 'ms' ),
 			'label2'               => __( 'More than 20 000 clients', 'ms' ),
-			'footer_btn_one_text'  => __( 'Start free trial', 'ms' ),
+			'footer_btn_one_text'  => __( 'Start a free trial', 'ms' ),
 			'footer_btn_one_url'   => __( '/trial/', 'ms' ),
 			'footer_btn_two_text'  => __( 'Request demo', 'ms' ),
 			'footer_btn_two_url'   => __( '/demo/', 'ms' ),

--- a/lib/shortcodes/signup-form-landingppc.php
+++ b/lib/shortcodes/signup-form-landingppc.php
@@ -13,7 +13,7 @@ function signup_form( $atts ) {
 			'title'    => __( 'Try it for free', 'ms' ),
 			'label1'   => __( 'Start a <strong>30-day trial</strong>, <span class="c-saturated-green">no credit card required</span>', 'ms' ),
 			'tooltip1' => __( 'Free trial for 30 days', 'ms' ),
-			'label2'   => __( 'No Credit Card required', 'ms' ),
+			'label2'   => __( 'No credit card required', 'ms' ),
 			'button'   => __( 'Create account for FREE', 'ms' ),
 		),
 		$atts,

--- a/lib/shortcodes/signup-form.php
+++ b/lib/shortcodes/signup-form.php
@@ -10,9 +10,9 @@ function ms_signup_form( $atts ) {
 
 	$atts = shortcode_atts(
 		array(
-			'title'    => __( 'Start Free Trial', 'ms' ),
-			'label1'   => __( '30 days free trial', 'ms' ),
-			'label2'   => __( 'No Credit Card required', 'ms' ),
+			'title'    => __( 'Start a Free Trial', 'ms' ),
+			'label1'   => __( '30-day free trial', 'ms' ),
+			'label2'   => __( 'No credit card required', 'ms' ),
 			'button'   => __( 'Create account for FREE', 'ms' ),
 		),
 		$atts,

--- a/lib/shortcodes/signup-sidebar.php
+++ b/lib/shortcodes/signup-sidebar.php
@@ -40,8 +40,8 @@ function ms_signup_sidebar( $atts ) {
 
 	// Default texts based on form_type
 	if ( 'Trial' === $atts['form_type'] ) {
-		$atts['title']    = __( 'Start Free Trial', 'ms' );
-		$atts['subtitle'] = __( '30 days free trial', 'ms' );
+		$atts['title']    = __( 'Start a Free Trial', 'ms' );
+		$atts['subtitle'] = __( '30-day free trial', 'ms' );
 		$atts['button']   = __( 'Create account for FREE', 'ms' );
 	} elseif ( 'FreeTrial' === $atts['form_type'] ) {
 		$atts['title']    = __( 'Try it for free', 'ms' );

--- a/template-redeem-code.php
+++ b/template-redeem-code.php
@@ -32,7 +32,7 @@ set_source( 'redeem-code', 'pages/TrialRedesign', 'css' );
 				<h1 class="Trial__main__title"><?php _e( 'LiveAgent registration <br />with <span class="highlight-gradient">a redeem code</span>', 'ms' ); ?></h1>
 				<p class="Trial__main__text"><?php _e( 'Finish your LiveAgent registration with your redeem code in the form below and get access to our extensive set of tools and features. Start providing superb customer service with LiveAgent today!', 'ms' ); ?></p>
 				<div class="Signup__form__labels Trial__labels">
-					<div class="Signup__form__labels__label"><?php _e( 'No Credit Card required', 'ms' ); ?></div>
+					<div class="Signup__form__labels__label"><?php _e( 'No credit card required', 'ms' ); ?></div>
 				</div>
 
 				<?= do_shortcode( '[signupform-redeemcode]' ); ?>

--- a/template-trial-redesign.php
+++ b/template-trial-redesign.php
@@ -44,7 +44,7 @@
 					<div class="Signup__form__labels__label">
 						<?php _e( '30-day free trial', 'ms' ); ?>&nbsp;
 					</div>
-					<div class="Signup__form__labels__label"><?php _e( 'No Credit Card required', 'ms' ); ?></div>
+					<div class="Signup__form__labels__label"><?php _e( 'No credit card required', 'ms' ); ?></div>
 				</div>
 
 				<?= do_shortcode( '[signupform]' ); ?>

--- a/template-trial-redesign.php
+++ b/template-trial-redesign.php
@@ -31,7 +31,7 @@
 
 			<div class="Trial__main__inner">
 				<h1 class="Trial__main__title"><?php _e( 'Start your <span class="highlight-gradient">free trial</span> today', 'ms' ); ?></h1>
-				<p class="Trial__main__text"><?php _e( 'Experience working with LiveAgent for free with our 30 days free trial. Enjoy a helpdesk platform with all advanced features and capabilities for free without any strings attached.', 'ms' ); ?></p>
+				<p class="Trial__main__text"><?php _e( 'Experience working with LiveAgent for free with our 30-day free trial. Enjoy a helpdesk platform with all advanced features and capabilities for free without any strings attached.', 'ms' ); ?></p>
 				<div class="Signup__form__labels Trial__labels">
 					<div class="Signup__form__labels__label limited">
 						<?php _e( 'Limited pricing offer', 'ms' ); ?>
@@ -42,7 +42,7 @@
 						</div>
 					</div>
 					<div class="Signup__form__labels__label">
-						<?php _e( '30 days free trial', 'ms' ); ?>&nbsp;
+						<?php _e( '30-day free trial', 'ms' ); ?>&nbsp;
 					</div>
 					<div class="Signup__form__labels__label"><?php _e( 'No Credit Card required', 'ms' ); ?></div>
 				</div>

--- a/templates/content-archive-ms_alternatives.php
+++ b/templates/content-archive-ms_alternatives.php
@@ -75,12 +75,12 @@
 													<div class="pricing__tags">
 														<div class="pricing__tags__label">
 														<?php
-														_e( '30 days free trial', 'alternatives' );
+														_e( '30-day free trial', 'alternatives' );
 														?>
 														</div>
 														<div class="pricing__tags__label">
 														<?php
-														_e( 'No Credit Card required', 'alternatives' );
+														_e( 'No credit card required', 'alternatives' );
 														?>
 														</div>
 														<div class="pricing__tags__label"><?php _e( 'and many more', 'alternatives' ); ?> </div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -411,6 +411,6 @@ if ( show_demo_bar() !== false ) {
 ?>
 
 <div class="trial__sticky__button">
-	<a href="<?= esc_url( '/trial/' ); ?>"><?= esc_html( 'Start Free Trial', 'ms' ); ?></a>
+	<a href="<?= esc_url( '/trial/' ); ?>"><?= esc_html( 'Start a Free Trial', 'ms' ); ?></a>
 	<span class="trial__sticky__button--close">x</span>
 </div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed grammatical errors  in the "Start free trial" widget

**Testing instructions**
- Go to trial page or e.g. /help-desk-software/ and check texts and button
- Should be "Experience working with LiveAgent for free with our 30-day free trial.", "Start a free trial", "No credit card required" and button "30-day free trial"
![image](https://github.com/user-attachments/assets/ec796ede-3ea4-42b0-8a85-f322fa93095a)
![image](https://github.com/user-attachments/assets/464a0746-dd6a-49da-a247-e78f2440c7f4)


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close issue https://github.com/QualityUnit/web-issues/issues/3587