### PR TITLE
[3821] - fix: make 'Customer Story' translatable in success stories shortcode

### DIFF
--- a/lib/shortcodes/success-stories-cards.php
+++ b/lib/shortcodes/success-stories-cards.php
@@ -118,7 +118,7 @@ function ms_success_stories_cards( $atts ) {
 							}
 							?>
 							<div class="success__stories__item__content__main">
-								<div class="success__stories__item__content__main__label"><?= esc_html( 'Customer Story' ); ?></div>
+								<div class="success__stories__item__content__main__label"><?= esc_html( __( 'Customer Story', 'ms' ) ); ?></div>
 								<div class="success__stories__item__content__main__headline">
 									<div class="headline"><?= esc_html( $headline ); ?></div>
 								</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Made 'Customer Story' translatable in success stories shortcode

**Testing instructions**
- Go to WPML plugin and scan new strings for translation, 'Customer Story' should be in the list

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3821
